### PR TITLE
fix: logging for debug messages

### DIFF
--- a/lib/gdal/cpl_error_handler.rb
+++ b/lib/gdal/cpl_error_handler.rb
@@ -65,11 +65,15 @@ module GDAL
 
     def initialize
       @on_none = SUCCESS_PROC
-      @on_debug = SUCCESS_PROC
+
+      @on_debug = lambda do |_, message|
+        logger.debug(message)
+        true
+      end
 
       @on_warning = lambda do |_, message|
-        warn(message)
-        false
+        logger.warn(message)
+        true
       end
 
       @on_failure = FAIL_PROC


### PR DESCRIPTION
GDAL sends debug messages via `CE_Debug` instead of STDOUT.
So, we need to properly log debug messages instead of suppressing them.

Also, I switched to `logger.debug` and `logger.warn` to utilize Logger (included from LogSwitch) instead of ruby internal `warn` method.

Before:
```ruby
require "gdal"
FFI::CPL::Conv.CPLSetConfigOption("CPL_DEBUG", "ON")
FFI::CPL::Conv.CPLSetConfigOption("AWS_NO_SIGN_REQUEST", "TRUE")
GDAL::Dataset.open("/vsis3/sentinel-cogs/sentinel-s2-l2a-cogs/15/S/TB/2020/11/S2A_15STB_20201130_0_L2A/B02.tif", "r")
# No output.
```

After:
```ruby
require "gdal"
FFI::CPL::Conv.CPLSetConfigOption("CPL_DEBUG", "ON")
FFI::CPL::Conv.CPLSetConfigOption("AWS_NO_SIGN_REQUEST", "TRUE")
GDAL::Dataset.open("/vsis3/sentinel-cogs/sentinel-s2-l2a-cogs/15/S/TB/2020/11/S2A_15STB_20201130_0_L2A/B02.tif", "r")
D, [2024-04-01T21:25:56.415970 #25430] DEBUG -- : HTTP: libcurl/7.81.0 GnuTLS/3.7.3 zlib/1.2.11 brotli/1.0.9 zstd/1.4.8 libidn2/2.3.2 libpsl/0.21.0 (+libidn2/2.3.2) libssh/0.9.6/openssl/zlib nghttp2/1.43.0 librtmp/2.3 OpenLDAP/2.5.17
D, [2024-04-01T21:25:57.314611 #25430] DEBUG -- : S3: Downloading 0-16383 (https://sentinel-cogs.s3.amazonaws.com/sentinel-s2-l2a-cogs/15/S/TB/2020/11/S2A_15STB_20201130_0_L2A/B02.tif)...
D, [2024-04-01T21:25:57.604171 #25430] DEBUG -- : S3: Got response_code=206
D, [2024-04-01T21:25:57.605796 #25430] DEBUG -- : GDAL: GDALOpen(/vsis3/sentinel-cogs/sentinel-s2-l2a-cogs/15/S/TB/2020/11/S2A_15STB_20201130_0_L2A/B02.tif, this=0xaaaaf4647f20) succeeds as GTiff.
```