### PR TITLE
fix: basic ractors support

### DIFF
--- a/lib/gdal/cpl_error_handler.rb
+++ b/lib/gdal/cpl_error_handler.rb
@@ -10,17 +10,17 @@ module GDAL
     include GDAL::Logger
 
     CPLE_MAP = [
-      { cple: :CPLE_None,           exception: nil },
-      { cple: :CPLE_AppDefined,     exception: GDAL::Error },
-      { cple: :CPLE_OutOfMemory,    exception: ::NoMemoryError },
-      { cple: :CPLE_FileIO,         exception: ::IOError },
-      { cple: :CPLE_OpenFailed,     exception: GDAL::OpenFailure },
-      { cple: :CPLE_IllegalArg,     exception: ::ArgumentError },
-      { cple: :CPLE_NotSupported,   exception: GDAL::UnsupportedOperation },
-      { cple: :CPLE_AssertionFailed, exception: ::RuntimeError },
-      { cple: :CPLE_NoWriteAccess,  exception: GDAL::NoWriteAccess },
-      { cple: :CPLE_UserInterrupt,  exception: ::Interrupt },
-      { cple: :CPLE_ObjectNull,     exception: GDAL::NullObject }
+      { cple: :CPLE_None,           exception: nil }.freeze,
+      { cple: :CPLE_AppDefined,     exception: GDAL::Error }.freeze,
+      { cple: :CPLE_OutOfMemory,    exception: ::NoMemoryError }.freeze,
+      { cple: :CPLE_FileIO,         exception: ::IOError }.freeze,
+      { cple: :CPLE_OpenFailed,     exception: GDAL::OpenFailure }.freeze,
+      { cple: :CPLE_IllegalArg,     exception: ::ArgumentError }.freeze,
+      { cple: :CPLE_NotSupported,   exception: GDAL::UnsupportedOperation }.freeze,
+      { cple: :CPLE_AssertionFailed, exception: ::RuntimeError }.freeze,
+      { cple: :CPLE_NoWriteAccess,  exception: GDAL::NoWriteAccess }.freeze,
+      { cple: :CPLE_UserInterrupt,  exception: ::Interrupt }.freeze,
+      { cple: :CPLE_ObjectNull,     exception: GDAL::NullObject }.freeze
     ].freeze
 
     FAIL_PROC = lambda do |exception, message|

--- a/spec/integration/gdal/dataset_ractors_spec.rb
+++ b/spec/integration/gdal/dataset_ractors_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "ffi-gdal"
+require "gdal"
+require "gdal/dataset"
+
+RSpec.describe "Dataset with Ractors", type: :integration do
+  let(:tiff1) do
+    path = "../../../spec/support/images/osgeo/geotiff/GeogToWGS84GeoKey/GeogToWGS84GeoKey5.tif"
+    File.expand_path(path, __dir__)
+  end
+  let(:tiff2) do
+    path = "../../../spec/support/images/123.tiff"
+    File.expand_path(path, __dir__)
+  end
+  let(:dataset_paths) { [tiff1, tiff2] }
+
+  if Object.const_defined?("Ractor")
+    it "succesfully open datasets in Ractor threads" do
+      ractors = dataset_paths.map do |file_path|
+        Ractor.new(file_path) do |file_path_r|
+          GDAL::Dataset.open(file_path_r, "r", shared: false)
+        end
+      end
+
+      datasets = ractors.map(&:take)
+
+      expect(datasets.size).to eq(2)
+      expect(datasets.map(&:description)).to contain_exactly(tiff1, tiff2)
+
+      datasets.each(&:close)
+    end
+  end
+end


### PR DESCRIPTION
`ffi` 1.16+ (CRuby 3.1+) have support for Ractors (https://github.com/ffi/ffi/wiki/Ractors).

With Ractors, we could open and make operations with datasets in parallel. This is very useful when we need to open/read datasets via a network (`vsis3`, `vsicurl`, etc).