### PR TITLE
feat: initial GDAL Utils support

### DIFF
--- a/lib/ffi/gdal.rb
+++ b/lib/ffi/gdal.rb
@@ -22,6 +22,7 @@ module FFI
     autoload :Matching, File.expand_path("gdal/matching.rb", __dir__)
     autoload :RPCInfo, File.expand_path("gdal/rpc_info.rb", __dir__)
     autoload :TransformerInfo, File.expand_path("gdal/transformer_info.rb", __dir__)
+    autoload :Utils, File.expand_path("gdal/utils.rb", __dir__)
     autoload :VRT, File.expand_path("gdal/vrt.rb", __dir__)
     autoload :Warper, File.expand_path("gdal/warper.rb", __dir__)
     autoload :WarpOptions, File.expand_path("gdal/warp_options.rb", __dir__)

--- a/lib/ffi/gdal/utils.rb
+++ b/lib/ffi/gdal/utils.rb
@@ -1,0 +1,984 @@
+# frozen_string_literal: true
+
+require "ffi"
+require_relative "../../ext/ffi_library_function_checks"
+
+module FFI
+  module GDAL
+    module Utils
+      extend FFI::Library
+      ffi_lib [::FFI::CURRENT_PROCESS, ::FFI::GDAL.gdal_library_path]
+
+      # -----------------------------------------------------------------------
+      # Typedefs
+      # -----------------------------------------------------------------------
+
+      ##############################################
+      ### Common arguments for utility functions ###
+      ##############################################
+
+      # GDALDatasetH -- the dataset handle (typical result of GDAL Utils).
+      typedef FFI::GDAL::GDAL.find_type(:GDALDatasetH), :GDALDatasetH
+
+      # papszArgv -- NULL terminated list of options (potentially including filename and open options too), or NULL.
+      # The accepted options are the ones of the according gdal* utility.
+      typedef :pointer, :papszArgv
+
+      # psOptionsForBinary -- (output) may be NULL (and should generally be NULL).
+      # NOTE: We don't use it in the Ruby-fied API. Keeping for documentation purposes.
+      typedef :pointer, :psOptionsForBinary
+
+      # pszDest -- the destination dataset path.
+      typedef :string, :pszDest
+
+      # hDataset -- the dataset handle.
+      typedef :GDALDatasetH, :hDataset
+
+      # hSrcDataset -- the source dataset handle
+      typedef :GDALDatasetH, :hSrcDataset
+
+      # hDstDS -- the destination dataset handle.
+      typedef :GDALDatasetH, :hDstDS
+
+      # nSrcCount -- the number of input datasets.
+      typedef :int, :nSrcCount
+
+      # pahSrcDS -- the list of input datasets.
+      typedef :pointer, :pahSrcDS
+
+      # pszProcessing -- the processing to apply
+      # (one of "hillshade", "slope", "aspect", "color-relief", "TRI", "TPI", "Roughness")
+      # NOTE: Only used by GDALDEMProcessing.
+      typedef :string, :pszProcessing
+
+      # pszColorFilename -- color file (mandatory for "color-relief" processing, should be NULL otherwise)
+      # NOTE: Only used by GDALDEMProcessing.
+      typedef :string, :pszColorFilename
+
+      # pbUsageError -- pointer to a integer output variable to store if any usage error has occurred or NULL.
+      typedef :pointer, :pbUsageError
+
+      ########################################
+      ### Pointers to GDAL Options Structs ###
+      ########################################
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv415GDALInfoOptions
+      typedef :pointer, :GDALInfoOptions
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv420GDALTranslateOptions
+      typedef :pointer, :GDALTranslateOptions
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv418GDALWarpAppOptions
+      typedef :pointer, :GDALWarpAppOptions
+
+      # # https://gdal.org/api/gdal_utils.html#_CPPv426GDALVectorTranslateOptions
+      typedef :pointer, :GDALVectorTranslateOptions
+
+      # # https://gdal.org/api/gdal_utils.html#_CPPv424GDALDEMProcessingOptions
+      typedef :pointer, :GDALDEMProcessingOptions
+
+      # # https://gdal.org/api/gdal_utils.html#_CPPv420GDALNearblackOptions
+      typedef :pointer, :GDALNearblackOptions
+
+      # # https://gdal.org/api/gdal_utils.html#_CPPv415GDALGridOptions
+      typedef :pointer, :GDALGridOptions
+
+      # # https://gdal.org/api/gdal_utils.html#_CPPv420GDALRasterizeOptions
+      typedef :pointer, :GDALRasterizeOptions
+
+      # # https://gdal.org/api/gdal_utils.html#_CPPv420GDALFootprintOptions
+      typedef :pointer, :GDALFootprintOptions
+
+      # # https://gdal.org/api/gdal_utils.html#_CPPv419GDALBuildVRTOptions
+      typedef :pointer, :GDALBuildVRTOptions
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv423GDALMultiDimInfoOptions
+      typedef :pointer, :GDALMultiDimInfoOptions
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv428GDALMultiDimTranslateOptions
+      typedef :pointer, :GDALMultiDimTranslateOptions
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv421GDALVectorInfoOptions
+      typedef :pointer, :GDALVectorInfoOptions
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv420GDALTileIndexOptions
+      typedef :pointer, :GDALTileIndexOptions
+
+      # -----------------------------------------------------------------------
+      # Functions
+      # -----------------------------------------------------------------------
+
+      ################
+      ### GDALInfo ###
+      ################
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv418GDALInfoOptionsNewPPcP24GDALInfoOptionsForBinary
+      # GDALInfoOptions *GDALInfoOptionsNew(char **papszArgv, GDALInfoOptionsForBinary *psOptionsForBinary)
+      #
+      # Allocates a GDALInfoOptions struct.
+      #
+      # Since
+      #   GDAL 2.1
+      # Parameters:
+      #    papszArgv -- NULL terminated list of options (potentially including filename and open options too), or NULL.
+      #      The accepted options are the ones of the gdalinfo utility.
+      #   psOptionsForBinary -- (output) may be NULL (and should generally be NULL), otherwise (gdalinfo_bin.cpp
+      #     use case) must be allocated with GDALInfoOptionsForBinaryNew() prior to this function.
+      #     Will be filled with potentially present filename, open options, subdataset number...
+      # Returns:
+      #   pointer to the allocated GDALInfoOptions struct. Must be freed with GDALInfoOptionsFree().
+      attach_function :GDALInfoOptionsNew, %i[papszArgv psOptionsForBinary], :GDALInfoOptions
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv419GDALInfoOptionsFreeP15GDALInfoOptions
+      # void GDALInfoOptionsFree(GDALInfoOptions *psOptions)
+      #
+      # Frees the GDALInfoOptions struct.
+      #
+      # Since
+      #   GDAL 2.1
+      # Parameters:
+      #   psOptions -- the options struct for GDALInfo().
+      attach_function :GDALInfoOptionsFree, [:GDALInfoOptions], :void
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv48GDALInfo12GDALDatasetHPK15GDALInfoOptions
+      # char *GDALInfo(GDALDatasetH hDataset, const GDALInfoOptions *psOptions)
+      #
+      # Lists various information about a GDAL supported raster dataset.
+      # This is the equivalent of the gdalinfo utility.
+      # GDALInfoOptions* must be allocated and freed with GDALInfoOptionsNew() and GDALInfoOptionsFree() respectively.
+      #
+      # Since
+      #   GDAL 2.1
+      # Parameters:
+      #   hDataset -- the dataset handle.
+      #   psOptions -- the options structure returned by GDALInfoOptionsNew() or NULL.
+      # Returns:
+      #   string corresponding to the information about the raster dataset (must be freed with CPLFree()), or NULL
+      #     in case of error.
+      attach_function :GDALInfo,
+                      %i[hDataset GDALInfoOptions],
+                      :strptr
+
+      #####################
+      ### GDALTranslate ###
+      #####################
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv423GDALTranslateOptionsNewPPcP29GDALTranslateOptionsForBinary
+      # GDALTranslateOptions *GDALTranslateOptionsNew(
+      #   char **papszArgv,
+      #   GDALTranslateOptionsForBinary *psOptionsForBinary
+      # )
+      #
+      # Allocates a GDALTranslateOptions struct.
+      #
+      # Since
+      #   GDAL 2.1
+      # Parameters:
+      #   papszArgv -- NULL terminated list of options (potentially including filename and open options too), or NULL.
+      #     The accepted options are the ones of the gdal_translate utility.
+      #   psOptionsForBinary -- (output) may be NULL (and should generally be NULL), otherwise (gdal_translate_bin.cpp
+      #     use case) must be allocated with GDALTranslateOptionsForBinaryNew() prior to this function.
+      #     Will be filled with potentially present filename, open options,...
+      # Returns:
+      #   pointer to the allocated GDALTranslateOptions struct. Must be freed with GDALTranslateOptionsFree().
+      attach_function :GDALTranslateOptionsNew, %i[papszArgv psOptionsForBinary], :GDALTranslateOptions
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv424GDALTranslateOptionsFreeP20GDALTranslateOptions
+      # void GDALTranslateOptionsFree(GDALTranslateOptions *psOptions)
+      #
+      # Frees the GDALTranslateOptions struct.
+      #
+      # Since
+      #   GDAL 2.1
+      # Parameters:
+      #   psOptions -- the options struct for GDALTranslate().
+      attach_function :GDALTranslateOptionsFree, [:GDALTranslateOptions], :void
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv413GDALTranslatePKc12GDALDatasetHPK20GDALTranslateOptionsPi
+      # GDALDatasetH GDALTranslate(
+      #   const char *pszDestFilename,
+      #   GDALDatasetH hSrcDataset,
+      #   const GDALTranslateOptions *psOptions,
+      #   int *pbUsageError
+      # )
+      #
+      # Converts raster data between different formats.
+      # This is the equivalent of the gdal_translate utility.
+      # GDALTranslateOptions* must be allocated and freed with GDALTranslateOptionsNew() and
+      # GDALTranslateOptionsFree() respectively.
+      #
+      # Since
+      #   GDAL 2.1
+      # Parameters:
+      #   pszDest -- the destination dataset path.
+      #   hSrcDataset -- the source dataset handle.
+      #   psOptionsIn -- the options struct returned by GDALTranslateOptionsNew() or NULL.
+      #   pbUsageError -- pointer to a integer output variable to store if any usage error has occurred or NULL.
+      # Returns:
+      #   the output dataset (new dataset that must be closed using GDALClose()) or NULL in case of error.
+      #     If the output format is a VRT dataset, then the returned VRT dataset has a reference to hSrcDataset.
+      #     Hence hSrcDataset should be closed after the returned dataset if using GDALClose().
+      #     A safer alternative is to use GDALReleaseDataset() instead of using GDALClose(),
+      #     in which case you can close datasets in any order.
+      attach_function :GDALTranslate,
+                      %i[pszDest hSrcDataset GDALTranslateOptions pbUsageError],
+                      :GDALDatasetH
+
+      ################
+      ### GDALWarp ###
+      ################
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv421GDALWarpAppOptionsNewPPcP27GDALWarpAppOptionsForBinary
+      # GDALWarpAppOptions *GDALWarpAppOptionsNew(char **papszArgv, GDALWarpAppOptionsForBinary *psOptionsForBinary)
+      #
+      # Allocates a GDALWarpAppOptions struct.
+      #
+      # Since
+      #   GDAL 2.1
+      # Parameters:
+      #   papszArgv -- NULL terminated list of options (potentially including filename and open options too), or NULL.
+      #     The accepted options are the ones of the gdalwarp utility.
+      #   psOptionsForBinary -- (output) may be NULL (and should generally be NULL), otherwise (gdal_translate_bin.cpp
+      #     use case) must be allocated with GDALWarpAppOptionsForBinaryNew() prior to this function.
+      #     Will be filled with potentially present filename, open options,...
+      # Returns:
+      #   pointer to the allocated GDALWarpAppOptions struct. Must be freed with GDALWarpAppOptionsFree().
+      attach_function :GDALWarpAppOptionsNew, %i[papszArgv psOptionsForBinary], :GDALWarpAppOptions
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv422GDALWarpAppOptionsFreeP18GDALWarpAppOptions
+      # void GDALWarpAppOptionsFree(GDALWarpAppOptions *psOptions)
+      #
+      # Frees the GDALWarpAppOptions struct.
+      #
+      # Since
+      #   GDAL 2.1
+      # Parameters:
+      #   psOptions -- the options struct for GDALWarp().
+      attach_function :GDALWarpAppOptionsFree, [:GDALWarpAppOptions], :void
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv48GDALWarpPKc12GDALDatasetHiP12GDALDatasetHPK18GDALWarpAppOptionsPi
+      # GDALDatasetH GDALWarp(
+      #   const char *pszDest,
+      #   GDALDatasetH hDstDS,
+      #   int nSrcCount,
+      #   GDALDatasetH *pahSrcDS,
+      #   const GDALWarpAppOptions *psOptions,
+      #   int *pbUsageError
+      # )
+      #
+      # Image reprojection and warping function.
+      # This is the equivalent of the gdalwarp utility.
+      # GDALWarpAppOptions* must be allocated and freed with GDALWarpAppOptionsNew() and
+      # GDALWarpAppOptionsFree() respectively. pszDest and hDstDS cannot be used at the same time.
+      #
+      # Since
+      #   GDAL 2.1
+      # Parameters:
+      #   pszDest -- the destination dataset path or NULL.
+      #   hDstDS -- the destination dataset or NULL.
+      #   nSrcCount -- the number of input datasets.
+      #   pahSrcDS -- the list of input datasets. For practical purposes, the type of this argument should be
+      #     considered as "const GDALDatasetH* const*", that is neither the array nor its values are mutated by
+      #     this function.
+      #   psOptionsIn -- the options struct returned by GDALWarpAppOptionsNew() or NULL.
+      #   pbUsageError -- pointer to a integer output variable to store if any usage error has occurred, or NULL.
+      # Returns:
+      #   the output dataset (new dataset that must be closed using GDALClose(), or hDstDS if not NULL) or NULL
+      #     in case of error. If the output format is a VRT dataset, then the returned VRT dataset has
+      #     a reference to pahSrcDS[0]. Hence pahSrcDS[0] should be closed after the returned dataset if
+      #     using GDALClose(). A safer alternative is to use GDALReleaseDataset() instead of using GDALClose(), in
+      #     which case you can close datasets in any order.
+      attach_function :GDALWarp,
+                      %i[pszDest hDstDS nSrcCount pahSrcDS GDALWarpAppOptions pbUsageError],
+                      :GDALDatasetH
+
+      ###########################
+      ### GDALVectorTranslate ###
+      ###########################
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv429GDALVectorTranslateOptionsNewPPcP35GDALVectorTranslateOptionsForBinary
+      # GDALVectorTranslateOptions *GDALVectorTranslateOptionsNew(
+      #   char **papszArgv,
+      #   GDALVectorTranslateOptionsForBinary *psOptionsForBinary
+      # )
+      #
+      # Allocates a GDALVectorTranslateOptions struct.
+      #
+      # Since
+      #   GDAL 2.1
+      # Parameters:
+      #   papszArgv -- NULL terminated list of options (potentially including filename and open options too), or NULL.
+      #     The accepted options are the ones of the ogr2ogr utility.
+      #   psOptionsForBinary -- (output) may be NULL (and should generally be NULL), otherwise (gdal_translate_bin.cpp
+      #     use case) must be allocated with GDALVectorTranslateOptionsForBinaryNew() prior to this function.
+      #     Will be filled with potentially present filename, open options,...
+      # Returns:
+      #   pointer to the allocated GDALVectorTranslateOptions struct. Must be freed with
+      #     GDALVectorTranslateOptionsFree().
+      attach_function :GDALVectorTranslateOptionsNew, %i[papszArgv psOptionsForBinary], :GDALVectorTranslateOptions
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv430GDALVectorTranslateOptionsFreeP26GDALVectorTranslateOptions
+      # void GDALVectorTranslateOptionsFree(GDALVectorTranslateOptions *psOptions)
+      #
+      # Frees the GDALVectorTranslateOptions struct.
+      #
+      # Since
+      #   GDAL 2.1
+      # Parameters:
+      #   psOptions -- the options struct for GDALVectorTranslate().
+      attach_function :GDALVectorTranslateOptionsFree, [:GDALVectorTranslateOptions], :void
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv419GDALVectorTranslatePKc12GDALDatasetHiP12GDALDatasetHPK26GDALVectorTranslateOptionsPi
+      # GDALDatasetH GDALVectorTranslate(
+      #   const char *pszDest,
+      #   GDALDatasetH hDstDS,
+      #   int nSrcCount,
+      #   GDALDatasetH *pahSrcDS,
+      #   const GDALVectorTranslateOptions *psOptions,
+      #   int *pbUsageError
+      # )
+      #
+      # Converts vector data between file formats.
+      # This is the equivalent of the ogr2ogr utility.
+      # GDALVectorTranslateOptions* must be allocated and freed with GDALVectorTranslateOptionsNew() and
+      # GDALVectorTranslateOptionsFree() respectively. pszDest and hDstDS cannot be used at the same time.
+      #
+      # Since
+      #   GDAL 2.1
+      # Parameters:
+      #   pszDest -- the destination dataset path or NULL.
+      #   hDstDS -- the destination dataset or NULL.
+      #   nSrcCount -- the number of input datasets (only 1 supported currently)
+      #   pahSrcDS -- the list of input datasets.
+      #   psOptionsIn -- the options struct returned by GDALVectorTranslateOptionsNew() or NULL.
+      #   pbUsageError -- pointer to a integer output variable to store if any usage error has occurred, or NULL.
+      # Returns:
+      #   the output dataset (new dataset that must be closed using GDALClose(), or hDstDS is not NULL) or NULL
+      #     in case of error.
+      attach_function :GDALVectorTranslate,
+                      %i[pszDest hDstDS nSrcCount pahSrcDS GDALVectorTranslateOptions pbUsageError],
+                      :GDALDatasetH
+
+      #########################
+      ### GDALDEMProcessing ###
+      #########################
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv427GDALDEMProcessingOptionsNewPPcP33GDALDEMProcessingOptionsForBinary
+      # GDALDEMProcessingOptions *GDALDEMProcessingOptionsNew(
+      #   char **papszArgv,
+      #   GDALDEMProcessingOptionsForBinary *psOptionsForBinary
+      # )
+      #
+      # Allocates a GDALDEMProcessingOptions struct.
+      #
+      # Since
+      #   GDAL 2.1
+      # Parameters:
+      #   papszArgv -- NULL terminated list of options (potentially including filename and open options too), or NULL.
+      #     The accepted options are the ones of the gdaldem utility.
+      #   psOptionsForBinary -- (output) may be NULL (and should generally be NULL), otherwise (gdal_translate_bin.cpp
+      #     use case) must be allocated with GDALDEMProcessingOptionsForBinaryNew() prior to this function.
+      #     Will be filled with potentially present filename, open options,...
+      # Returns:
+      #   pointer to the allocated GDALDEMProcessingOptions struct. Must be freed with GDALDEMProcessingOptionsFree().
+      attach_function :GDALDEMProcessingOptionsNew, %i[papszArgv psOptionsForBinary], :GDALDEMProcessingOptions
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv428GDALDEMProcessingOptionsFreeP24GDALDEMProcessingOptions
+      # void GDALDEMProcessingOptionsFree(GDALDEMProcessingOptions *psOptions)
+      #
+      # Frees the GDALDEMProcessingOptions struct.
+      #
+      # Since
+      #   GDAL 2.1
+      # Parameters:
+      #   psOptions -- the options struct for GDALDEMProcessing().
+      attach_function :GDALDEMProcessingOptionsFree, [:GDALDEMProcessingOptions], :void
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv417GDALDEMProcessingPKc12GDALDatasetHPKcPKcPK24GDALDEMProcessingOptionsPi
+      # GDALDatasetH GDALDEMProcessing(
+      #   const char *pszDestFilename,
+      #   GDALDatasetH hSrcDataset,
+      #   const char *pszProcessing,
+      #   const char *pszColorFilename,
+      #   const GDALDEMProcessingOptions *psOptions,
+      #   int *pbUsageError
+      # )
+      #
+      # Apply a DEM processing.
+      # This is the equivalent of the gdaldem utility.
+      # GDALDEMProcessingOptions* must be allocated and freed with GDALDEMProcessingOptionsNew() and
+      # GDALDEMProcessingOptionsFree() respectively.
+      #
+      # Since
+      #   GDAL 2.1
+      # Parameters:
+      #   pszDest -- the destination dataset path.
+      #   hSrcDataset -- the source dataset handle.
+      #   pszProcessing -- the processing to apply (one of "hillshade", "slope", "aspect", "color-relief", "TRI",
+      #     "TPI", "Roughness")
+      #   pszColorFilename -- color file (mandatory for "color-relief" processing, should be NULL otherwise)
+      #   psOptionsIn -- the options struct returned by GDALDEMProcessingOptionsNew() or NULL.
+      #   pbUsageError -- pointer to a integer output variable to store if any usage error has occurred or NULL.
+      # Returns:
+      #   the output dataset (new dataset that must be closed using GDALClose()) or NULL in case of error.
+      attach_function :GDALDEMProcessing,
+                      %i[pszDest hSrcDataset pszProcessing pszColorFilename GDALDEMProcessingOptions pbUsageError],
+                      :GDALDatasetH
+
+      #####################
+      ### GDALNearblack ###
+      #####################
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv423GDALNearblackOptionsNewPPcP29GDALNearblackOptionsForBinary
+      # GDALNearblackOptions *GDALNearblackOptionsNew(
+      #   char **papszArgv,
+      #   GDALNearblackOptionsForBinary *psOptionsForBinary
+      # )
+      #
+      # Allocates a GDALNearblackOptions struct.
+      #
+      # Since
+      #   GDAL 2.1
+      # Parameters:
+      #   papszArgv -- NULL terminated list of options (potentially including filename and open options too), or NULL.
+      #     The accepted options are the ones of the nearblack utility.
+      #   psOptionsForBinary -- (output) may be NULL (and should generally be NULL), otherwise (gdal_translate_bin.cpp
+      #     use case) must be allocated with GDALNearblackOptionsForBinaryNew() prior to this function.
+      #     Will be filled with potentially present filename, open options,...
+      # Returns:
+      #   pointer to the allocated GDALNearblackOptions struct. Must be freed with GDALNearblackOptionsFree().
+      attach_function :GDALNearblackOptionsNew, %i[papszArgv psOptionsForBinary], :GDALNearblackOptions
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv424GDALNearblackOptionsFreeP20GDALNearblackOptions
+      # void GDALNearblackOptionsFree(GDALNearblackOptions *psOptions)
+      #
+      # Frees the GDALNearblackOptions struct.
+      #
+      # Since
+      #   GDAL 2.1
+      # Parameters:
+      #   psOptions -- the options struct for GDALNearblack().
+      attach_function :GDALNearblackOptionsFree, [:GDALNearblackOptions], :void
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv413GDALNearblackPKc12GDALDatasetH12GDALDatasetHPK20GDALNearblackOptionsPi
+      # GDALDatasetH GDALNearblack(
+      #   const char *pszDest,
+      #   GDALDatasetH hDstDS,
+      #   GDALDatasetH hSrcDS,
+      #   const GDALNearblackOptions *psOptions,
+      #   int *pbUsageError
+      # )
+      #
+      # Convert nearly black/white borders to exact value.
+      # This is the equivalent of the nearblack utility.
+      # GDALNearblackOptions* must be allocated and freed with GDALNearblackOptionsNew()
+      # and GDALNearblackOptionsFree() respectively. pszDest and hDstDS cannot be used at the same time.
+      # In-place update (i.e. hDstDS == hSrcDataset) is possible for formats that support it,
+      # and if the dataset is opened in update mode.
+      #
+      # Since
+      #   GDAL 2.1
+      # Parameters:
+      #   pszDest -- the destination dataset path or NULL.
+      #   hDstDS -- the destination dataset or NULL. Might be equal to hSrcDataset.
+      #   hSrcDataset -- the source dataset handle.
+      #   psOptionsIn -- the options struct returned by GDALNearblackOptionsNew() or NULL.
+      #   pbUsageError -- pointer to a integer output variable to store if any usage error has occurred or NULL.
+      # Returns:
+      #   the output dataset (new dataset that must be closed using GDALClose(), or hDstDS when it is not NULL) or NULL
+      #     in case of error.
+      attach_function :GDALNearblack,
+                      %i[pszDest hDstDS hSrcDataset GDALNearblackOptions pbUsageError],
+                      :GDALDatasetH
+
+      ################
+      ### GDALGrid ###
+      ################
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv418GDALGridOptionsNewPPcP24GDALGridOptionsForBinary
+      # GDALGridOptions *GDALGridOptionsNew(char **papszArgv, GDALGridOptionsForBinary *psOptionsForBinary)
+      #
+      # Allocates a GDALGridOptions struct.
+      #
+      # Since
+      #   GDAL 2.1
+      # Parameters:
+      #   papszArgv -- NULL terminated list of options (potentially including filename and open options too), or NULL.
+      #     The accepted options are the ones of the gdal_translate utility.
+      #   psOptionsForBinary -- (output) may be NULL (and should generally be NULL), otherwise (gdal_translate_bin.cpp
+      #     use case) must be allocated with GDALGridOptionsForBinaryNew() prior to this function.
+      #     Will be filled with potentially present filename, open options,...
+      # Returns:
+      #   pointer to the allocated GDALGridOptions struct. Must be freed with GDALGridOptionsFree().
+      attach_function :GDALGridOptionsNew, %i[papszArgv psOptionsForBinary], :GDALGridOptions
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv419GDALGridOptionsFreeP15GDALGridOptions
+      # void GDALGridOptionsFree(GDALGridOptions *psOptions)
+      #
+      # Frees the GDALGridOptions struct.
+      #
+      # Since
+      #   GDAL 2.1
+      # Parameters:
+      #   psOptions -- the options struct for GDALGrid().
+      attach_function :GDALGridOptionsFree, [:GDALGridOptions], :void
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv48GDALGridPKc12GDALDatasetHPK15GDALGridOptionsPi
+      # GDALDatasetH GDALGrid(
+      #   const char *pszDest,
+      #   GDALDatasetH hSrcDS,
+      #   const GDALGridOptions *psOptions,
+      #   int *pbUsageError
+      # )
+      #
+      # Create raster from the scattered data.
+      # This is the equivalent of the gdal_grid utility.
+      # GDALGridOptions* must be allocated and freed with GDALGridOptionsNew() and GDALGridOptionsFree() respectively.
+      #
+      # Since
+      #   GDAL 2.1
+      # Parameters:
+      #   pszDest -- the destination dataset path.
+      #   hSrcDataset -- the source dataset handle.
+      #   psOptionsIn -- the options struct returned by GDALGridOptionsNew() or NULL.
+      #   pbUsageError -- pointer to a integer output variable to store if any usage error has occurred or NULL.
+      # Returns:
+      #   the output dataset (new dataset that must be closed using GDALClose()) or NULL in case of error.
+      attach_function :GDALGrid,
+                      %i[pszDest hSrcDataset GDALGridOptions pbUsageError],
+                      :GDALDatasetH
+
+      #####################
+      ### GDALRasterize ###
+      #####################
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv423GDALRasterizeOptionsNewPPcP29GDALRasterizeOptionsForBinary
+      # GDALRasterizeOptions *GDALRasterizeOptionsNew(
+      #   char **papszArgv,
+      #   GDALRasterizeOptionsForBinary *psOptionsForBinary
+      # )
+      #
+      # Allocates a GDALRasterizeOptions struct.
+      #
+      # Since
+      #   GDAL 2.1
+      # Parameters:
+      #   papszArgv -- NULL terminated list of options (potentially including filename and open options too), or NULL.
+      #     The accepted options are the ones of the gdal_rasterize utility.
+      #   psOptionsForBinary -- (output) may be NULL (and should generally be NULL), otherwise (gdal_translate_bin.cpp
+      #     use case) must be allocated with GDALRasterizeOptionsForBinaryNew() prior to this function.
+      #     Will be filled with potentially present filename, open options,...
+      # Returns:
+      #   pointer to the allocated GDALRasterizeOptions struct. Must be freed with GDALRasterizeOptionsFree().
+      attach_function :GDALRasterizeOptionsNew, %i[papszArgv psOptionsForBinary], :GDALRasterizeOptions
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv424GDALRasterizeOptionsFreeP20GDALRasterizeOptions
+      # void GDALRasterizeOptionsFree(GDALRasterizeOptions *psOptions)
+      #
+      # Frees the GDALRasterizeOptions struct.
+      #
+      # Since
+      #   GDAL 2.1
+      # Parameters:
+      #   psOptions -- the options struct for GDALRasterize().
+      attach_function :GDALRasterizeOptionsFree, [:GDALRasterizeOptions], :void
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv413GDALRasterizePKc12GDALDatasetH12GDALDatasetHPK20GDALRasterizeOptionsPi
+      # GDALDatasetH GDALRasterize(
+      #   const char *pszDest,
+      #   GDALDatasetH hDstDS,
+      #   GDALDatasetH hSrcDS,
+      #   const GDALRasterizeOptions *psOptions,
+      #   int *pbUsageError
+      # )
+      #
+      # Burns vector geometries into a raster.
+      # This is the equivalent of the gdal_rasterize utility.
+      # GDALRasterizeOptions* must be allocated and freed with GDALRasterizeOptionsNew() and
+      # GDALRasterizeOptionsFree() respectively. pszDest and hDstDS cannot be used at the same time.
+      #
+      # Since
+      #   GDAL 2.1
+      # Parameters:
+      #   pszDest -- the destination dataset path or NULL.
+      #   hDstDS -- the destination dataset or NULL.
+      #   hSrcDataset -- the source dataset handle.
+      #   psOptionsIn -- the options struct returned by GDALRasterizeOptionsNew() or NULL.
+      #   pbUsageError -- pointer to a integer output variable to store if any usage error has occurred or NULL.
+      # Returns:
+      #   the output dataset (new dataset that must be closed using GDALClose(), or hDstDS is not NULL) or NULL
+      #     in case of error.
+      attach_function :GDALRasterize,
+                      %i[pszDest hDstDS hSrcDataset GDALRasterizeOptions pbUsageError],
+                      :GDALDatasetH
+
+      #####################
+      ### GDALFootprint ###
+      #####################
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv423GDALFootprintOptionsNewPPcP29GDALFootprintOptionsForBinary
+      # GDALFootprintOptions *GDALFootprintOptionsNew(
+      #   char **papszArgv,
+      #   GDALFootprintOptionsForBinary *psOptionsForBinary
+      # )
+      #
+      # Allocates a GDALFootprintOptions struct.
+      #
+      # Since
+      #   GDAL 3.8
+      # Parameters:
+      #   papszArgv -- NULL terminated list of options (potentially including filename and open options too), or NULL.
+      #     The accepted options are the ones of the gdal_rasterize utility.
+      #   psOptionsForBinary -- (output) may be NULL (and should generally be NULL), otherwise (gdal_translate_bin.cpp
+      #     use case) must be allocated with GDALFootprintOptionsForBinaryNew() prior to this function.
+      #     Will be filled with potentially present filename, open options,...
+      # Returns:
+      #   pointer to the allocated GDALFootprintOptions struct. Must be freed with GDALFootprintOptionsFree().
+      attach_function :GDALFootprintOptionsNew, %i[papszArgv psOptionsForBinary], :GDALFootprintOptions
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv424GDALFootprintOptionsFreeP20GDALFootprintOptions
+      # void GDALFootprintOptionsFree(GDALFootprintOptions *psOptions)
+      #
+      # Frees the GDALFootprintOptions struct.
+      #
+      # Since
+      #   GDAL 3.8
+      # Parameters:
+      #   psOptions -- the options struct for GDALFootprint().
+      attach_function :GDALFootprintOptionsFree, [:GDALFootprintOptions], :void
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv413GDALFootprintPKc12GDALDatasetH12GDALDatasetHPK20GDALFootprintOptionsPi
+      # GDALDatasetH GDALFootprint(
+      #   const char *pszDest,
+      #   GDALDatasetH hDstDS,
+      #   GDALDatasetH hSrcDS,
+      #   const GDALFootprintOptions *psOptions,
+      #   int *pbUsageError
+      # )
+      #
+      # Computes the footprint of a raster.
+      # This is the equivalent of the gdal_footprint utility.
+      # GDALFootprintOptions* must be allocated and freed with GDALFootprintOptionsNew() and
+      # GDALFootprintOptionsFree() respectively. pszDest and hDstDS cannot be used at the same time.
+      #
+      # Since
+      #   GDAL 3.8
+      # Parameters:
+      #   pszDest -- the vector destination dataset path or NULL.
+      #   hDstDS -- the vector destination dataset or NULL.
+      #   hSrcDataset -- the raster source dataset handle.
+      #   psOptionsIn -- the options struct returned by GDALFootprintOptionsNew() or NULL.
+      #   pbUsageError -- pointer to a integer output variable to store if any usage error has occurred or NULL.
+      # Returns:
+      #   the output dataset (new dataset that must be closed using GDALClose(), or hDstDS is not NULL) or NULL
+      #     in case of error.
+      attach_function :GDALFootprint,
+                      %i[pszDest hDstDS hSrcDataset GDALFootprintOptions pbUsageError],
+                      :GDALDatasetH
+
+      ####################
+      ### GDALBuildVRT ###
+      ####################
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv422GDALBuildVRTOptionsNewPPcP28GDALBuildVRTOptionsForBinary
+      # GDALBuildVRTOptions *GDALBuildVRTOptionsNew(char **papszArgv, GDALBuildVRTOptionsForBinary *psOptionsForBinary)
+      #
+      # Allocates a GDALBuildVRTOptions struct.
+      #
+      # Since
+      #   GDAL 2.1
+      # Parameters:
+      #   papszArgv -- NULL terminated list of options (potentially including filename and open options too), or NULL.
+      #     The accepted options are the ones of the gdalbuildvrt utility.
+      #   psOptionsForBinary -- (output) may be NULL (and should generally be NULL), otherwise (gdalbuildvrt_bin.cpp
+      #     use case) must be allocated with GDALBuildVRTOptionsForBinaryNew() prior to this function.
+      #     Will be filled with potentially present filename, open options,...
+      # Returns:
+      #   pointer to the allocated GDALBuildVRTOptions struct. Must be freed with GDALBuildVRTOptionsFree().
+      attach_function :GDALBuildVRTOptionsNew, %i[papszArgv psOptionsForBinary], :GDALBuildVRTOptions
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv423GDALBuildVRTOptionsFreeP19GDALBuildVRTOptions
+      # void GDALBuildVRTOptionsFree(GDALBuildVRTOptions *psOptions)
+      #
+      # Frees the GDALBuildVRTOptions struct.
+      #
+      # Since
+      #   GDAL 2.1
+      # Parameters:
+      #   psOptions -- the options struct for GDALBuildVRT().
+      attach_function :GDALBuildVRTOptionsFree, [:GDALBuildVRTOptions], :void
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv412GDALBuildVRTPKciP12GDALDatasetHPPCKcPK19GDALBuildVRTOptionsPi
+      # GDALDatasetH GDALBuildVRT(
+      #   const char *pszDest,
+      #   int nSrcCount,
+      #   GDALDatasetH *pahSrcDS,
+      #   const char *const *papszSrcDSNames,
+      #   const GDALBuildVRTOptions *psOptions,
+      #   int *pbUsageError
+      # )
+      #
+      # Build a VRT from a list of datasets.
+      # This is the equivalent of the gdalbuildvrt utility.
+      # GDALBuildVRTOptions* must be allocated and freed with GDALBuildVRTOptionsNew()
+      # and GDALBuildVRTOptionsFree() respectively. pahSrcDS and papszSrcDSNames cannot be used at the same time.
+      #
+      # Since
+      #   GDAL 2.1
+      # Parameters:
+      #   pszDest -- the destination dataset path.
+      #   nSrcCount -- the number of input datasets.
+      #   pahSrcDS -- the list of input datasets (or NULL, exclusive with papszSrcDSNames).
+      #     For practical purposes, the type of this argument should be considered as "const GDALDatasetH* const*",
+      #     that is neither the array nor its values are mutated by this function.
+      #   papszSrcDSNames -- the list of input dataset names (or NULL, exclusive with pahSrcDS)
+      #   psOptionsIn -- the options struct returned by GDALBuildVRTOptionsNew() or NULL.
+      #   pbUsageError -- pointer to a integer output variable to store if any usage error has occurred.
+      # Returns:
+      #   the output dataset (new dataset that must be closed using GDALClose()) or NULL in case of error.
+      #     If using pahSrcDS, the returned VRT dataset has a reference to each pahSrcDS[] element.
+      #     Hence pahSrcDS[] elements should be closed after the returned dataset if using GDALClose().
+      #     A safer alternative is to use GDALReleaseDataset() instead of using GDALClose(), in which case
+      #     you can close datasets in any order.
+      attach_function :GDALBuildVRT,
+                      %i[pszDest nSrcCount pahSrcDS pointer GDALBuildVRTOptions pbUsageError],
+                      :GDALDatasetH
+
+      ########################
+      ### GDALMultiDimInfo ###
+      ########################
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv426GDALMultiDimInfoOptionsNewPPcP32GDALMultiDimInfoOptionsForBinary
+      # GDALMultiDimInfoOptions *GDALMultiDimInfoOptionsNew(
+      #   char **papszArgv,
+      #   GDALMultiDimInfoOptionsForBinary *psOptionsForBinary
+      # )
+      #
+      # Allocates a GDALMultiDimInfoOptions struct.
+      #
+      # Since
+      #   GDAL 3.1
+      # Parameters:
+      #   papszArgv -- NULL terminated list of options (potentially including filename and open options too), or NULL.
+      #     The accepted options are the ones of the gdalmdiminfo utility.
+      #   psOptionsForBinary -- should be nullptr, unless called from gdalmultidiminfo_bin.cpp
+      # Returns:
+      #   pointer to the allocated GDALMultiDimInfoOptions struct. Must be freed with GDALMultiDimInfoOptionsFree().
+      attach_function :GDALMultiDimInfoOptionsNew, %i[papszArgv psOptionsForBinary], :GDALMultiDimInfoOptions
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv427GDALMultiDimInfoOptionsFreeP23GDALMultiDimInfoOptions
+      # void GDALMultiDimInfoOptionsFree(GDALMultiDimInfoOptions *psOptions)
+      #
+      # Frees the GDALMultiDimInfoOptions struct.
+      #
+      # Since
+      #   GDAL 3.1
+      # Parameters:
+      #   psOptions -- the options struct for GDALMultiDimInfo().
+      attach_function :GDALMultiDimInfoOptionsFree, [:GDALMultiDimInfoOptions], :void
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv416GDALMultiDimInfo12GDALDatasetHPK23GDALMultiDimInfoOptions
+      # char *GDALMultiDimInfo(GDALDatasetH hDataset, const GDALMultiDimInfoOptions *psOptions)
+      #
+      # Lists various information about a GDAL multidimensional dataset.
+      # This is the equivalent of the gdalmdiminfoutility.
+      # GDALMultiDimInfoOptions* must be allocated and freed with GDALMultiDimInfoOptionsNew() and
+      # GDALMultiDimInfoOptionsFree() respectively.
+      #
+      # Since
+      #   GDAL 3.1
+      # Parameters:
+      #   hDataset -- the dataset handle.
+      #   psOptionsIn -- the options structure returned by GDALMultiDimInfoOptionsNew() or NULL.
+      # Returns:
+      #   string corresponding to the information about the raster dataset (must be freed with CPLFree()), or NULL
+      #     in case of error.
+      attach_function :GDALMultiDimInfo,
+                      %i[hDataset GDALMultiDimInfoOptions],
+                      :strptr
+
+      #############################
+      ### GDALMultiDimTranslate ###
+      #############################
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv431GDALMultiDimTranslateOptionsNewPPcP37GDALMultiDimTranslateOptionsForBinary
+      # GDALMultiDimTranslateOptions *GDALMultiDimTranslateOptionsNew(
+      #   char **papszArgv,
+      #   GDALMultiDimTranslateOptionsForBinary *psOptionsForBinary
+      # )
+      #
+      # Allocates a GDALMultiDimTranslateOptions struct.
+      #
+      # Since
+      #   GDAL 3.1
+      # Parameters:
+      #   papszArgv -- NULL terminated list of options (potentially including filename and open options too), or NULL.
+      #     The accepted options are the ones of the gdalmdimtranslate utility.
+      #   psOptionsForBinary -- should be nullptr, unless called from gdalmdimtranslate_bin.cpp
+      # Returns:
+      #   pointer to the allocated GDALMultiDimTranslateOptions struct. Must be freed with
+      #     GDALMultiDimTranslateOptionsFree().
+      attach_function :GDALMultiDimTranslateOptionsNew, %i[papszArgv psOptionsForBinary], :GDALMultiDimTranslateOptions
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv432GDALMultiDimTranslateOptionsFreeP28GDALMultiDimTranslateOptions
+      # void GDALMultiDimTranslateOptionsFree(GDALMultiDimTranslateOptions *psOptions)
+      #
+      # Frees the GDALMultiDimTranslateOptions struct.
+      #
+      # Since
+      #   GDAL 3.1
+      # Parameters:
+      #   psOptions -- the options struct for GDALMultiDimTranslate().
+      attach_function :GDALMultiDimTranslateOptionsFree, [:GDALMultiDimTranslateOptions], :void
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv421GDALMultiDimTranslatePKc12GDALDatasetHiP12GDALDatasetHPK28GDALMultiDimTranslateOptionsPi
+      # GDALDatasetH GDALMultiDimTranslate(
+      #   const char *pszDest,
+      #   GDALDatasetH hDstDataset,
+      #   int nSrcCount,
+      #   GDALDatasetH *pahSrcDS,
+      #   const GDALMultiDimTranslateOptions *psOptions,
+      #   int *pbUsageError
+      # )
+      #
+      # Converts raster data between different formats.
+      # This is the equivalent of the gdalmdimtranslate utility.
+      # GDALMultiDimTranslateOptions* must be allocated and freed with GDALMultiDimTranslateOptionsNew()
+      # and GDALMultiDimTranslateOptionsFree() respectively. pszDest and hDstDS cannot be used at the same time.
+      #
+      # Since
+      #   GDAL 3.1
+      # Parameters:
+      #   pszDest -- the destination dataset path or NULL.
+      #   hDstDS -- the destination dataset or NULL.
+      #   nSrcCount -- the number of input datasets.
+      #   pahSrcDS -- the list of input datasets.
+      #   psOptions -- the options struct returned by GDALMultiDimTranslateOptionsNew() or NULL.
+      #   pbUsageError -- pointer to a integer output variable to store if any usage error has occurred or NULL.
+      # Returns:
+      #   the output dataset (new dataset that must be closed using GDALClose(), or hDstDS is not NULL) or NULL
+      #     in case of error.
+      attach_function :GDALMultiDimTranslate,
+                      %i[pszDest hDstDS nSrcCount pahSrcDS GDALMultiDimTranslateOptions pbUsageError],
+                      :GDALDatasetH
+
+      ######################
+      ### GDALVectorInfo ###
+      ######################
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv424GDALVectorInfoOptionsNewPPcP30GDALVectorInfoOptionsForBinary
+      # GDALVectorInfoOptions *GDALVectorInfoOptionsNew(
+      #   char **papszArgv,
+      #   GDALVectorInfoOptionsForBinary *psOptionsForBinary
+      # )
+      #
+      # Allocates a GDALVectorInfoOptions struct.
+      #
+      # Since
+      #   GDAL 3.7
+      # Parameters:
+      #   papszArgv -- NULL terminated list of options (potentially including filename and open options too), or NULL.
+      #     The accepted options are the ones of the ogrinfo utility.
+      #   psOptionsForBinary -- (output) may be NULL (and should generally be NULL), otherwise (ogrinfo_bin.cpp
+      #     use case) must be allocated with GDALVectorInfoOptionsForBinaryNew() prior to this function.
+      #     Will be filled with potentially present filename, open options, subdataset number...
+      # Returns:
+      #   pointer to the allocated GDALVectorInfoOptions struct. Must be freed with GDALVectorInfoOptionsFree().
+      attach_function :GDALVectorInfoOptionsNew, %i[papszArgv psOptionsForBinary], :GDALVectorInfoOptions
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv425GDALVectorInfoOptionsFreeP21GDALVectorInfoOptions
+      # void GDALVectorInfoOptionsFree(GDALVectorInfoOptions *psOptions)
+      #
+      # Frees the GDALVectorInfoOptions struct.
+      #
+      # Since
+      #   GDAL 3.7
+      # Parameters:
+      #   psOptions -- the options struct for GDALVectorInfo().
+      attach_function :GDALVectorInfoOptionsFree, [:GDALVectorInfoOptions], :void
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv414GDALVectorInfo12GDALDatasetHPK21GDALVectorInfoOptions
+      # char *GDALVectorInfo(GDALDatasetH hDataset, const GDALVectorInfoOptions *psOptions)
+      #
+      # Lists various information about a GDAL supported vector dataset.
+      # This is the equivalent of the ogrinfo utility.
+      # GDALVectorInfoOptions* must be allocated and freed with GDALVectorInfoOptionsNew()
+      # and GDALVectorInfoOptionsFree() respectively.
+      #
+      # Since
+      #   GDAL 3.7
+      # Parameters:
+      #   hDataset -- the dataset handle.
+      #   psOptions -- the options structure returned by GDALVectorInfoOptionsNew() or NULL.
+      # Returns:
+      #   string corresponding to the information about the raster dataset (must be freed with CPLFree()), or NULL
+      #     in case of error.
+      attach_function :GDALVectorInfo,
+                      %i[hDataset GDALVectorInfoOptions],
+                      :strptr
+
+      #####################
+      ### GDALTileIndex ###
+      #####################
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv423GDALTileIndexOptionsNewPPcP29GDALTileIndexOptionsForBinary
+      # GDALTileIndexOptions *GDALTileIndexOptionsNew(
+      #   char **papszArgv,
+      #   GDALTileIndexOptionsForBinary *psOptionsForBinary
+      # )
+      #
+      # Allocates a GDALTileIndexOptions struct.
+      #
+      # Since
+      #   GDAL 3.9
+      # Parameters:
+      #   papszArgv -- NULL terminated list of options (potentially including filename and open options too), or NULL.
+      #     The accepted options are the ones of the gdaltindex utility.
+      #   psOptionsForBinary -- (output) may be NULL (and should generally be NULL), otherwise (gdaltindex_bin.cpp
+      #     use case) must be allocated with GDALTileIndexOptionsForBinaryNew() prior to this function.
+      #     Will be filled with potentially present filename, open options,...
+      # Returns:
+      #   pointer to the allocated GDALTileIndexOptions struct. Must be freed with GDALTileIndexOptionsFree().
+      attach_function :GDALTileIndexOptionsNew, %i[papszArgv psOptionsForBinary], :GDALTileIndexOptions
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv424GDALTileIndexOptionsFreeP20GDALTileIndexOptions
+      # void GDALTileIndexOptionsFree(GDALTileIndexOptions *psOptions)
+      #
+      # Frees the GDALTileIndexOptions struct.
+      #
+      # Since
+      #   GDAL 3.9
+      # Parameters:
+      #   psOptions -- the options struct for GDALTileIndex().
+      attach_function :GDALTileIndexOptionsFree, [:GDALTileIndexOptions], :void
+
+      # https://gdal.org/api/gdal_utils.html#_CPPv413GDALTileIndexPKciPPCKcPK20GDALTileIndexOptionsPi
+      # GDALDatasetH GDALTileIndex(
+      #   const char *pszDest,
+      #   int nSrcCount,
+      #   const char *const *papszSrcDSNames,
+      #   const GDALTileIndexOptions *psOptions,
+      #   int *pbUsageError
+      # )
+      #
+      # Build a tile index from a list of datasets.
+      # This is the equivalent of the gdaltindex utility.
+      # GDALTileIndexOptions* must be allocated and freed with GDALTileIndexOptionsNew()
+      # and GDALTileIndexOptionsFree() respectively.
+      #
+      # Since
+      #   GDAL 3.9
+      # Parameters:
+      #   pszDest -- the destination dataset path.
+      #   nSrcCount -- the number of input datasets.
+      #   papszSrcDSNames -- the list of input dataset names
+      #   psOptionsIn -- the options struct returned by GDALTileIndexOptionsNew() or NULL.
+      #   pbUsageError -- pointer to a integer output variable to store if any usage error has occurred.
+      # Returns:
+      #   the output dataset (new dataset that must be closed using GDALClose()) or NULL in case of error.
+      attach_function :GDALTileIndex,
+                      %i[pszDest nSrcCount pointer GDALTileIndexOptions pbUsageError],
+                      :GDALDatasetH
+    end
+  end
+end

--- a/lib/gdal.rb
+++ b/lib/gdal.rb
@@ -37,6 +37,7 @@ module GDAL
   autoload :Options,              gdal_require("gdal/options")
   autoload :RasterAttributeTable, gdal_require("gdal/raster_attribute_table")
   autoload :RasterBand,           gdal_require("gdal/raster_band")
+  autoload :Utils,                gdal_require("gdal/utils")
 end
 
 require_relative "gdal/exceptions"

--- a/lib/gdal/utils.rb
+++ b/lib/gdal/utils.rb
@@ -10,6 +10,7 @@ module GDAL
     autoload :Helpers, File.expand_path("utils/helpers", __dir__)
 
     # GDAL Utils
+    autoload :Grid, File.expand_path("utils/grid", __dir__)
     autoload :Rasterize, File.expand_path("utils/rasterize", __dir__)
     autoload :Info, File.expand_path("utils/info", __dir__)
     autoload :Translate, File.expand_path("utils/translate", __dir__)

--- a/lib/gdal/utils.rb
+++ b/lib/gdal/utils.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module GDAL
+  # Wrappers for the GDAL utilities.
+  #
+  # @see https://gdal.org/programs/index.html GDAL Utils documentation (gdalwarp, gdal_translate, ...).
+  # @see https://gdal.org/api/gdal_utils.html GDAL Utils C API.
+  module Utils
+    # Internal helpers
+    autoload :Helpers, File.expand_path("utils/helpers", __dir__)
+
+    # GDAL Utils
+    autoload :Info, File.expand_path("utils/info", __dir__)
+    autoload :Translate, File.expand_path("utils/translate", __dir__)
+    autoload :VectorTranslate, File.expand_path("utils/vector_translate", __dir__)
+    autoload :Warp, File.expand_path("utils/warp", __dir__)
+  end
+end

--- a/lib/gdal/utils.rb
+++ b/lib/gdal/utils.rb
@@ -10,6 +10,7 @@ module GDAL
     autoload :Helpers, File.expand_path("utils/helpers", __dir__)
 
     # GDAL Utils
+    autoload :DEM, File.expand_path("utils/dem", __dir__)
     autoload :Grid, File.expand_path("utils/grid", __dir__)
     autoload :Rasterize, File.expand_path("utils/rasterize", __dir__)
     autoload :Info, File.expand_path("utils/info", __dir__)

--- a/lib/gdal/utils.rb
+++ b/lib/gdal/utils.rb
@@ -10,6 +10,7 @@ module GDAL
     autoload :Helpers, File.expand_path("utils/helpers", __dir__)
 
     # GDAL Utils
+    autoload :Rasterize, File.expand_path("utils/rasterize", __dir__)
     autoload :Info, File.expand_path("utils/info", __dir__)
     autoload :Translate, File.expand_path("utils/translate", __dir__)
     autoload :VectorTranslate, File.expand_path("utils/vector_translate", __dir__)

--- a/lib/gdal/utils.rb
+++ b/lib/gdal/utils.rb
@@ -12,6 +12,7 @@ module GDAL
     # GDAL Utils
     autoload :DEM, File.expand_path("utils/dem", __dir__)
     autoload :Grid, File.expand_path("utils/grid", __dir__)
+    autoload :Nearblack, File.expand_path("utils/nearblack", __dir__)
     autoload :Rasterize, File.expand_path("utils/rasterize", __dir__)
     autoload :Info, File.expand_path("utils/info", __dir__)
     autoload :Translate, File.expand_path("utils/translate", __dir__)

--- a/lib/gdal/utils/dem.rb
+++ b/lib/gdal/utils/dem.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require_relative "dem/options"
+
+module GDAL
+  module Utils
+    # Wrapper for gdaldem using GDALDEMProcessing C API.
+    #
+    # @see https://gdal.org/programs/gdaldem.html gdaldem utility documentation.
+    # @see https://gdal.org/api/gdal_utils.html#_CPPv417GDALDEMProcessingPKc12GDALDatasetHPKcPKcPK24GDALDEMProcessingOptionsPi
+    #   GDALDEMProcessing C API.
+    class DEM
+      # Perform the gdaldem (GDALDEMProcessing) operation.
+      #
+      # @example Create a raster dataset.
+      #   src_dataset = GDAL::Dataset.open("source.tif", "r")
+      #
+      #   dataset = GDAL::Utils::DEM.perform(
+      #     dst_dataset_path: "destination.tif",
+      #     src_dataset: src_dataset,
+      #     processing: "hillshade"
+      #   )
+      #
+      #   # Do something with the dataset.
+      #   puts dataset.raster_x_size
+      #
+      #   # You must close the dataset when you are done with it.
+      #   dataset.close
+      #   src_dataset.close
+      #
+      # @example Create a raster dataset for color-relief.
+      #   src_dataset = GDAL::Dataset.open("source.tif", "r")
+      #
+      #   dataset = GDAL::Utils::DEM.perform(
+      #     dst_dataset_path: "destination.tif",
+      #     src_dataset: src_dataset,
+      #     processing: "color-relief",
+      #     color_filename: "color.txt"
+      #   )
+      #
+      #   # Do something with the dataset.
+      #   puts dataset.raster_x_size
+      #
+      #   # You must close the dataset when you are done with it.
+      #   dataset.close
+      #   src_dataset.close
+      #
+      # @example Create a raster dataset with options.
+      #   src_dataset = GDAL::Dataset.open("source.tif", "r")
+      #   options = GDAL::Utils::DEM::Options.new(options: ["-of", "GTiff", "-co", "TILED=YES"])
+      #
+      #   dataset = GDAL::Utils::DEM.perform(
+      #     dst_dataset_path: "destination.tif",
+      #     src_dataset: src_dataset,
+      #     processing: "hillshade",
+      #     options: options
+      #   )
+      #
+      #   # Do something with the dataset.
+      #   puts dataset.raster_x_size
+      #
+      #   # You must close the dataset when you are done with it.
+      #   dataset.close
+      #   src_dataset.close
+      #
+      # @example Create a raster dataset using block syntax.
+      #   src_dataset = GDAL::Dataset.open("source.tif", "r")
+      #
+      #   GDAL::Utils::DEM.perform(
+      #     dst_dataset_path: "destination.tif",
+      #     src_dataset: src_dataset,
+      #     processing: "hillshade"
+      #   ) do |dataset|
+      #     # Do something with the dataset.
+      #     puts dataset.raster_x_size
+      #
+      #     # Dataset will be closed automatically.
+      #   end
+      #   src_dataset.close
+      #
+      # @param dst_dataset_path [String] The path to the destination dataset.
+      # @param src_dataset [OGR::DataSource] The source dataset.
+      # @param processing [String] The processing type
+      #   (one of "hillshade", "slope", "aspect", "color-relief", "TRI", "TPI", "Roughness").
+      # @param color_filename [String] color file (mandatory for "color-relief" processing, should be NULL otherwise).
+      # @param options [GDAL::Utils::DEM::Options] Options.
+      # @yield [GDAL::Dataset] The destination dataset.
+      # @return [GDAL::Dataset] The destination dataset (only if block is not specified; dataset must be closed).
+      # @raise [GDAL::Error] If the operation fails.
+      def self.perform(dst_dataset_path:, src_dataset:, processing:, color_filename: nil, options: Options.new, &block)
+        result_code_ptr = ::FFI::MemoryPointer.new(:int)
+        dst_dataset_ptr = ::FFI::GDAL::Utils.GDALDEMProcessing(
+          dst_dataset_path,
+          src_dataset.c_pointer,
+          processing,
+          color_filename,
+          options.c_pointer,
+          result_code_ptr
+        )
+        success = result_code_ptr.read_int.zero?
+
+        raise ::GDAL::Error, "GDALDEMProcessing failed." if dst_dataset_ptr.null? || !success
+
+        ::GDAL::Dataset.open(dst_dataset_ptr, "w", &block)
+      end
+    end
+  end
+end

--- a/lib/gdal/utils/dem/options.rb
+++ b/lib/gdal/utils/dem/options.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module GDAL
+  module Utils
+    class DEM
+      # Ruby wrapper for GDALDEMProcessingOptions C API (options for gdaldem utility).
+      #
+      # @see GDAL::Utils::DEM
+      # @see https://gdal.org/programs/gdaldem.html gdaldem utility documentation.
+      class Options
+        # @private
+        class AutoPointer < ::FFI::AutoPointer
+          # @param pointer [FFI::Pointer]
+          def self.release(pointer)
+            return unless pointer && !pointer.null?
+
+            ::FFI::GDAL::Utils.GDALDEMProcessingOptionsFree(pointer)
+          end
+        end
+
+        # @return [AutoPointer] C pointer to the GDALDEMProcessingOptions.
+        attr_reader :c_pointer
+
+        # @return [Array<String>] The options.
+        attr_reader :options
+
+        # Create a new instance.
+        #
+        # @see https://gdal.org/programs/gdaldem.html
+        #   List of available options could be found in gdaldem utility documentation.
+        #
+        # @example Create a new instance.
+        #  options = GDAL::Utils::DEM::Options.new(options: ["-of", "GTiff", "-co", "COMPRESS=DEFLATE"])
+        #
+        # @param options [Array<String>] The options list.
+        def initialize(options: [])
+          @options = options
+          @string_list = ::GDAL::Utils::Helpers::StringList.new(strings: options)
+          @c_pointer = AutoPointer.new(options_pointer)
+        end
+
+        private
+
+        attr_reader :string_list
+
+        def options_pointer
+          ::FFI::GDAL::Utils.GDALDEMProcessingOptionsNew(string_list.c_pointer, nil)
+        end
+      end
+    end
+  end
+end

--- a/lib/gdal/utils/grid.rb
+++ b/lib/gdal/utils/grid.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require_relative "grid/options"
+
+module GDAL
+  module Utils
+    # Wrapper for gdal_grid using GDALGrid C API.
+    #
+    # @see https://gdal.org/programs/gdal_grid.html gdal_grid utility documentation.
+    # @see https://gdal.org/api/gdal_utils.html#_CPPv48GDALGridPKc12GDALDatasetHPK15GDALGridOptionsPi GDALGrid C API.
+    class Grid
+      # Perform the gdal_grid (GDALGrid) operation.
+      #
+      # @example Create a raster dataset.
+      #   src_dataset = GDAL::Dataset.open("source.tif", "r")
+      #   dataset = GDAL::Utils::Grid.perform(dst_dataset_path: "destination.tif", src_dataset: src_dataset)
+      #
+      #   # Do something with the dataset.
+      #   puts dataset.raster_x_size
+      #
+      #   # You must close the dataset when you are done with it.
+      #   dataset.close
+      #   src_dataset.close
+      #
+      # @example Create a raster dataset with options.
+      #   src_dataset = GDAL::Dataset.open("source.tif", "r")
+      #   dataset = GDAL::Utils::Grid.perform(
+      #     dst_dataset_path: "destination.tif",
+      #     src_dataset: src_dataset,
+      #     options: GDAL::Utils::Grid::Options.new(options: ["-of", "GTiff", "-co", "COMPRESS=DEFLATE"])
+      #   )
+      #
+      #   # Do something with the dataset.
+      #   puts dataset.raster_x_size
+      #
+      #   # You must close the dataset when you are done with it.
+      #   dataset.close
+      #   src_dataset.close
+      #
+      # @example Create a raster dataset using block syntax.
+      #   src_dataset = GDAL::Dataset.open("source.tif", "r")
+      #   GDAL::Utils::Grid.perform(dst_dataset_path: "destination.tif", src_dataset: src_dataset) do |dataset|
+      #     # Do something with the dataset.
+      #     puts dataset.raster_x_size
+      #
+      #     # Dataset will be closed automatically.
+      #   end
+      #   src_dataset.close
+      #
+      # @param dst_dataset_path [String] The path to the destination dataset.
+      # @param src_dataset [OGR::DataSource] The source dataset.
+      # @param options [GDAL::Utils::Grid::Options] Options.
+      # @yield [GDAL::Dataset] The destination dataset.
+      # @return [GDAL::Dataset] The destination dataset (only if block is not specified; dataset must be closed).
+      # @raise [GDAL::Error] If the operation fails.
+      def self.perform(dst_dataset_path:, src_dataset:, options: Options.new, &block)
+        result_code_ptr = ::FFI::MemoryPointer.new(:int)
+        dst_dataset_ptr = ::FFI::GDAL::Utils.GDALGrid(
+          dst_dataset_path,
+          src_dataset.c_pointer,
+          options.c_pointer,
+          result_code_ptr
+        )
+        success = result_code_ptr.read_int.zero?
+
+        raise ::GDAL::Error, "GDALGrid failed." if dst_dataset_ptr.null? || !success
+
+        ::GDAL::Dataset.open(dst_dataset_ptr, "w", &block)
+      end
+    end
+  end
+end

--- a/lib/gdal/utils/grid/options.rb
+++ b/lib/gdal/utils/grid/options.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module GDAL
+  module Utils
+    class Grid
+      # Ruby wrapper for GDALGridOptions C API (options for gdal_grid utility).
+      #
+      # @see GDAL::Utils::Grid
+      # @see https://gdal.org/programs/gdal_grid.html gdal_grid utility documentation.
+      class Options
+        # @private
+        class AutoPointer < ::FFI::AutoPointer
+          # @param pointer [FFI::Pointer]
+          def self.release(pointer)
+            return unless pointer && !pointer.null?
+
+            ::FFI::GDAL::Utils.GDALGridOptionsFree(pointer)
+          end
+        end
+
+        # @return [AutoPointer] C pointer to the GDALGridOptions.
+        attr_reader :c_pointer
+
+        # @return [Array<String>] The options.
+        attr_reader :options
+
+        # Create a new instance.
+        #
+        # @see https://gdal.org/programs/gdal_grid.html
+        #   List of available options could be found in gdal_grid utility documentation.
+        #
+        # @example Create a new instance.
+        #  options = GDAL::Utils::Grid::Options.new(options: ["-of", "GTiff", "-outsize", "10", "10"])
+        #
+        # @param options [Array<String>] The options list.
+        def initialize(options: [])
+          @options = options
+          @string_list = ::GDAL::Utils::Helpers::StringList.new(strings: options)
+          @c_pointer = AutoPointer.new(options_pointer)
+        end
+
+        private
+
+        attr_reader :string_list
+
+        def options_pointer
+          ::FFI::GDAL::Utils.GDALGridOptionsNew(string_list.c_pointer, nil)
+        end
+      end
+    end
+  end
+end

--- a/lib/gdal/utils/helpers.rb
+++ b/lib/gdal/utils/helpers.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module GDAL
+  module Utils
+    # Internal helpers for GDAL Utils.
+    module Helpers
+      autoload :DatasetList, File.expand_path("helpers/dataset_list", __dir__)
+      autoload :StringList, File.expand_path("helpers/string_list", __dir__)
+    end
+  end
+end

--- a/lib/gdal/utils/helpers/dataset_list.rb
+++ b/lib/gdal/utils/helpers/dataset_list.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module GDAL
+  module Utils
+    module Helpers
+      # A basic wrapper for C Array of dataset handlers (e.g. GDALDatasetH *pahSrcDS).
+      #
+      # @private
+      # @note This class is intended only to be used internally in ffi-gdal. It's API may change.
+      #   Do not use this class directly.
+      class DatasetList
+        # @return [FFI::Pointer] C pointer to the Array of dataset handlers (e.g. GDALDatasetH *pahSrcDS).
+        attr_reader :c_pointer
+
+        # @return [Array<GDAL::Dataset>] List of datasets.
+        attr_reader :datasets
+
+        # @param datasets [Array<GDAL::Dataset>] List of datasets.
+        def initialize(datasets: [])
+          @datasets = datasets
+          @c_pointer = datasets_pointer
+        end
+
+        # @return [Integer] The number of datasets in the list.
+        def count
+          dataset_pointers.count
+        end
+
+        private
+
+        def dataset_pointers
+          @dataset_pointers ||= datasets.map(&:c_pointer)
+        end
+
+        def datasets_pointer
+          ::FFI::MemoryPointer
+            .new(:pointer, count)
+            .write_array_of_pointer(dataset_pointers)
+        end
+      end
+    end
+  end
+end

--- a/lib/gdal/utils/helpers/string_list.rb
+++ b/lib/gdal/utils/helpers/string_list.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module GDAL
+  module Utils
+    module Helpers
+      # A basic wrapper for CPLStringList (e.g. char **papszArgv).
+      #
+      # @private
+      # @note This class is intended only to be used internally in ffi-gdal. It's API may change.
+      #   Do not use this class directly.
+      class StringList
+        class AutoPointer < ::FFI::AutoPointer
+          # @param pointer [FFI::Pointer]
+          def self.release(pointer)
+            return unless pointer && !pointer.null?
+
+            ::FFI::CPL::String.CSLDestroy(pointer)
+          end
+        end
+
+        # @return [FFI::Pointer] C pointer to CPLStringList (e.g. char **papszArgv).
+        attr_reader :c_pointer
+
+        # @return [Array<String>] Strings in the list.
+        attr_reader :strings
+
+        # @param strings [Array<String>] Strings to build the list.
+        def initialize(strings: [])
+          @strings = strings
+          @c_pointer = AutoPointer.new(string_list_pointer)
+        end
+
+        private
+
+        def string_list_pointer
+          pointer = ::FFI::Pointer.new(FFI::Pointer::NULL)
+
+          strings.each do |string|
+            pointer = ::FFI::CPL::String.CSLAddString(pointer, string.to_s)
+          end
+
+          pointer
+        end
+      end
+    end
+  end
+end

--- a/lib/gdal/utils/info.rb
+++ b/lib/gdal/utils/info.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative "info/options"
+
+module GDAL
+  module Utils
+    # Wrapper for gdalinfo using GDALInfo C API.
+    #
+    # @see https://gdal.org/programs/gdalinfo.html gdalinfo utility documentation.
+    # @see https://gdal.org/api/gdal_utils.html#_CPPv48GDALInfo12GDALDatasetHPK15GDALInfoOptions GDALInfo C API.
+    class Info
+      # Perform the gdalinfo (GDALInfo) operation.
+      #
+      # @example Get info for a dataset.
+      #   dataset = GDAL::Dataset.open("my.tif", "r")
+      #   info = GDAL::Utils::Info.perform(dataset: dataset)
+      #   dataset.close
+      #
+      # @example Get info for a dataset with options.
+      #   dataset = GDAL::Dataset.open("my.tif", "r")
+      #   info = GDAL::Utils::Info.perform(
+      #     dataset: dataset,
+      #     options: GDAL::Utils::Info::Options.new(options: ["-json", "-mdd", "all"])
+      #   )
+      #   dataset.close
+      #
+      # @param dataset [GDAL::Dataset] The dataset to get info for.
+      # @param options [GDAL::Utils::Info::Options] Options.
+      # @return [String] The info string.
+      def self.perform(dataset:, options: Options.new)
+        string, str_pointer = ::FFI::GDAL::Utils.GDALInfo(dataset.c_pointer, options.c_pointer)
+
+        string
+      ensure
+        # Returned string pointer must be freed with CPLFree().
+        ::FFI::CPL::VSI.VSIFree(str_pointer)
+      end
+    end
+  end
+end

--- a/lib/gdal/utils/info/options.rb
+++ b/lib/gdal/utils/info/options.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module GDAL
+  module Utils
+    class Info
+      # Ruby wrapper for GDALInfoOptions C API (options for gdalinfo utility).
+      #
+      # @see GDAL::Utils::Info
+      # @see https://gdal.org/programs/gdalinfo.html gdalinfo utility documentation.
+      class Options
+        # @private
+        class AutoPointer < ::FFI::AutoPointer
+          # @param pointer [FFI::Pointer]
+          def self.release(pointer)
+            return unless pointer && !pointer.null?
+
+            ::FFI::GDAL::Utils.GDALInfoOptionsFree(pointer)
+          end
+        end
+
+        # @return [AutoPointer] C pointer to the GDALInfoOptions.
+        attr_reader :c_pointer
+
+        # @return [Array<String>] The options.
+        attr_reader :options
+
+        # Create a new instance.
+        #
+        # @see https://gdal.org/programs/gdalinfo.html
+        #   List of available options could be found in gdalinfo utility documentation.
+        #
+        # @example Create a new instance.
+        #  options = GDAL::Utils::Info::Options.new(options: ["-json", "-mdd", "all"])
+        #
+        # @param options [Array<String>] The options list.
+        def initialize(options: [])
+          @options = options
+          @string_list = ::GDAL::Utils::Helpers::StringList.new(strings: options)
+          @c_pointer = AutoPointer.new(options_pointer)
+        end
+
+        private
+
+        attr_reader :string_list
+
+        def options_pointer
+          ::FFI::GDAL::Utils.GDALInfoOptionsNew(string_list.c_pointer, nil)
+        end
+      end
+    end
+  end
+end

--- a/lib/gdal/utils/nearblack.rb
+++ b/lib/gdal/utils/nearblack.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require_relative "nearblack/options"
+
+module GDAL
+  module Utils
+    # Wrapper for nearblack using GDALNearblack C API.
+    #
+    # @see https://gdal.org/programs/nearblack.html nearblack utility documentation.
+    # @see https://gdal.org/api/gdal_utils.html#_CPPv413GDALNearblackPKc12GDALDatasetH12GDALDatasetHPK20GDALNearblackOptionsPi
+    #   GDALNearblack C API.
+    class Nearblack
+      # Perform the nearblack (GDALNearblack) operation.
+      #
+      # @example Perform nearblack on dataset (for dst_dataset_path).
+      #   src_dataset = GDAL::Dataset.open("source.tif", "r")
+      #
+      #   dataset = GDAL::Utils::Nearblack.perform(dst_dataset_path: "destination.tif", src_dataset: src_dataset)
+      #
+      #   # Do something with the dataset.
+      #   puts dataset.raster_x_size
+      #
+      #   # You must close the dataset when you are done with it.
+      #   dataset.close
+      #   src_dataset.close
+      #
+      # @example Perform nearblack on dataset with options (for dst_dataset_path).
+      #   src_dataset = GDAL::Dataset.open("source.tif", "r")
+      #   options = GDAL::Utils::Nearblack::Options.new(options: ["-near", "10"])
+      #
+      #   dataset = GDAL::Utils::Nearblack.perform(
+      #     dst_dataset_path: "destination.tif",
+      #     src_dataset: src_dataset,
+      #     options: options
+      #   )
+      #
+      #   # Do something with the dataset.
+      #   puts dataset.raster_x_size
+      #
+      #   # You must close the dataset when you are done with it.
+      #   dataset.close
+      #   src_dataset.close
+      #
+      # @example Perform nearblack on dataset (for dst_dataset_path) using block syntax.
+      #   src_dataset = GDAL::Dataset.open("source.tif", "r")
+      #   options = GDAL::Utils::Nearblack::Options.new(options: ["-near", "10"])
+      #
+      #   GDAL::Utils::Nearblack.perform(
+      #     dst_dataset_path: "destination.tif",
+      #     src_dataset: src_dataset,
+      #     options: options
+      #   ) do |dataset|
+      #     # Do something with the dataset.
+      #     puts dataset.raster_x_size
+      #
+      #     # Dataset will be closed automatically.
+      #   end
+      #   src_dataset.close
+      #
+      # @example Perform nearblack on dataset (for dst_dataset).
+      #   src_dataset = GDAL::Dataset.open("source.tif", "r")
+      #   dst_dataset = GDAL::Dataset.open("destination.tif", "w")
+      #
+      #   GDAL::Utils::Nearblack.perform(dst_dataset: dst_dataset, src_dataset: src_dataset)
+      #
+      #   # You must close the dataset when you are done with it.
+      #   dst_dataset.close
+      #   src_dataset.close
+      #
+      # @param dst_dataset_path [String] The path to the destination dataset.
+      # @param dst_dataset [GDAL::Dataset] The destination dataset.
+      # @param src_dataset [GDAL::Dataset] The source dataset.
+      # @param options [GDAL::Utils::Nearblack::Options] Options.
+      # @yield [GDAL::Dataset] The destination dataset.
+      # @return [GDAL::Dataset] The destination dataset (only if block is not specified; dataset must be closed).
+      def self.perform(src_dataset:, dst_dataset: nil, dst_dataset_path: nil, options: Options.new, &block)
+        if dst_dataset
+          for_dataset(dst_dataset: dst_dataset, src_dataset: src_dataset, options: options)
+        else
+          for_dataset_path(dst_dataset_path: dst_dataset_path, src_dataset: src_dataset, options: options, &block)
+        end
+      end
+
+      def self.for_dataset(dst_dataset:, src_dataset:, options: Options.new)
+        result_dataset_ptr(dst_dataset: dst_dataset, src_dataset: src_dataset, options: options)
+
+        # Return the input dataset as the output dataset (dataset is modified in place).
+        dst_dataset
+      end
+      private_class_method :for_dataset
+
+      def self.for_dataset_path(dst_dataset_path:, src_dataset:, options: Options.new, &block)
+        dst_dataset_ptr = result_dataset_ptr(
+          dst_dataset_path: dst_dataset_path, src_dataset: src_dataset, options: options
+        )
+
+        ::GDAL::Dataset.open(dst_dataset_ptr, "w", &block)
+      end
+      private_class_method :for_dataset_path
+
+      def self.result_dataset_ptr(src_dataset:, dst_dataset_path: nil, dst_dataset: nil, options: Options.new)
+        result_code_ptr = ::FFI::MemoryPointer.new(:int)
+        dst_dataset_ptr = ::FFI::GDAL::Utils.GDALNearblack(
+          dst_dataset_path,
+          dst_dataset&.c_pointer,
+          src_dataset.c_pointer,
+          options.c_pointer,
+          result_code_ptr
+        )
+        success = result_code_ptr.read_int.zero?
+
+        raise ::GDAL::Error, "GDALNearblack failed." if dst_dataset_ptr.null? || !success
+
+        dst_dataset_ptr
+      end
+      private_class_method :result_dataset_ptr
+    end
+  end
+end

--- a/lib/gdal/utils/nearblack/options.rb
+++ b/lib/gdal/utils/nearblack/options.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module GDAL
+  module Utils
+    class Nearblack
+      # Ruby wrapper for GDALNearblackOptions C API (options for nearblack utility).
+      #
+      # @see GDAL::Utils::Nearblack
+      # @see https://gdal.org/programs/nearblack.html nearblack utility documentation.
+      class Options
+        # @private
+        class AutoPointer < ::FFI::AutoPointer
+          # @param pointer [FFI::Pointer]
+          def self.release(pointer)
+            return unless pointer && !pointer.null?
+
+            ::FFI::GDAL::Utils.GDALNearblackOptionsFree(pointer)
+          end
+        end
+
+        # @return [AutoPointer] C pointer to the GDALNearblackOptions.
+        attr_reader :c_pointer
+
+        # @return [Array<String>] The options.
+        attr_reader :options
+
+        # Create a new instance.
+        #
+        # @see https://gdal.org/programs/nearblack.html
+        #   List of available options could be found in nearblack utility documentation.
+        #
+        # @example Create a new instance.
+        #  options = GDAL::Utils::Nearblack::Options.new(options: ["-of", "GTiff", "-near", "10"])
+        #
+        # @param options [Array<String>] The options list.
+        def initialize(options: [])
+          @options = options
+          @string_list = ::GDAL::Utils::Helpers::StringList.new(strings: options)
+          @c_pointer = AutoPointer.new(options_pointer)
+        end
+
+        private
+
+        attr_reader :string_list
+
+        def options_pointer
+          ::FFI::GDAL::Utils.GDALNearblackOptionsNew(string_list.c_pointer, nil)
+        end
+      end
+    end
+  end
+end

--- a/lib/gdal/utils/rasterize.rb
+++ b/lib/gdal/utils/rasterize.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require_relative "rasterize/options"
+
+module GDAL
+  module Utils
+    # Wrapper for gdal_rasterize using GDALRasterize C API.
+    #
+    # @see https://gdal.org/programs/gdal_rasterize.html gdal_rasterize utility documentation.
+    # @see https://gdal.org/api/gdal_utils.html#_CPPv413GDALRasterizePKc12GDALDatasetH12GDALDatasetHPK20GDALRasterizeOptionsPi
+    #   GDALRasterize C API.
+    class Rasterize
+      # Perform the gdal_rasterize (GDALRasterize) operation.
+      #
+      # @example Rasterize a dataset with options (for dst_dataset_path).
+      #   src_dataset = OGR::DataSource.open("source.shp", "r")
+      #   options = GDAL::Utils::Rasterize::Options.new(options: ["-ts", "10", "10"])
+      #
+      #   dataset = GDAL::Utils::Rasterize.perform(
+      #     dst_dataset_path: "destination.tif",
+      #     src_dataset: src_dataset,
+      #     options: options
+      #   )
+      #
+      #   # Do something with the dataset.
+      #   puts dataset.raster_x_size
+      #
+      #   # You must close the dataset when you are done with it.
+      #   dataset.close
+      #   src_dataset.close
+      #
+      # @example Rasterize a dataset (for dst_dataset_path) using block syntax.
+      #   src_dataset = OGR::DataSource.open("source.shp", "r")
+      #   options = GDAL::Utils::Rasterize::Options.new(options: ["-ts", "10", "10"])
+      #
+      #   GDAL::Utils::Rasterize.perform(
+      #     dst_dataset_path: "destination.tif",
+      #     src_dataset: src_dataset,
+      #     options: options
+      #   ) do |dataset|
+      #     # Do something with the dataset.
+      #     puts dataset.raster_x_size
+      #
+      #     # Dataset will be closed automatically.
+      #   end
+      #   src_dataset.close
+      #
+      # @example Rasterize a dataset (for dst_dataset).
+      #   src_dataset = OGR::DataSource.open("source.shp", "r")
+      #   dst_dataset = GDAL::Dataset.open("destination.tif", "w")
+      #   options = GDAL::Utils::Rasterize::Options.new(options: ["-ts", "10", "10"])
+      #
+      #   GDAL::Utils::Rasterize.perform(dst_dataset: dst_dataset, src_dataset: src_dataset, options: options)
+      #
+      #   # You must close the dataset when you are done with it.
+      #   dst_dataset.close
+      #   src_dataset.close
+      #
+      # @param dst_dataset_path [String] The path to the destination dataset.
+      # @param dst_dataset [GDAL::Dataset] The destination dataset.
+      # @param src_dataset [OGR::DataSource] The source dataset.
+      # @param options [GDAL::Utils::Rasterize::Options] Options.
+      # @yield [GDAL::Dataset] The destination dataset.
+      # @return [GDAL::Dataset] The destination dataset (only if block is not specified; dataset must be closed).
+      def self.perform(src_dataset:, dst_dataset: nil, dst_dataset_path: nil, options: Options.new, &block)
+        if dst_dataset
+          for_dataset(dst_dataset: dst_dataset, src_dataset: src_dataset, options: options)
+        else
+          for_dataset_path(dst_dataset_path: dst_dataset_path, src_dataset: src_dataset, options: options, &block)
+        end
+      end
+
+      def self.for_dataset(dst_dataset:, src_dataset:, options: Options.new)
+        result_dataset_ptr(dst_dataset: dst_dataset, src_dataset: src_dataset, options: options)
+
+        # Return the input dataset as the output dataset (dataset is modified in place).
+        dst_dataset
+      end
+      private_class_method :for_dataset
+
+      def self.for_dataset_path(dst_dataset_path:, src_dataset:, options: Options.new, &block)
+        dst_dataset_ptr = result_dataset_ptr(
+          dst_dataset_path: dst_dataset_path, src_dataset: src_dataset, options: options
+        )
+
+        ::GDAL::Dataset.open(dst_dataset_ptr, "w", &block)
+      end
+      private_class_method :for_dataset_path
+
+      def self.result_dataset_ptr(src_dataset:, dst_dataset_path: nil, dst_dataset: nil, options: Options.new)
+        result_code_ptr = ::FFI::MemoryPointer.new(:int)
+        dst_dataset_ptr = ::FFI::GDAL::Utils.GDALRasterize(
+          dst_dataset_path,
+          dst_dataset&.c_pointer,
+          src_dataset.c_pointer,
+          options.c_pointer,
+          result_code_ptr
+        )
+        success = result_code_ptr.read_int.zero?
+
+        raise ::GDAL::Error, "GDALRasterize failed." if dst_dataset_ptr.null? || !success
+
+        dst_dataset_ptr
+      end
+      private_class_method :result_dataset_ptr
+    end
+  end
+end

--- a/lib/gdal/utils/rasterize/options.rb
+++ b/lib/gdal/utils/rasterize/options.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module GDAL
+  module Utils
+    class Rasterize
+      # Ruby wrapper for GDALRasterizeOptions C API (options for gdal_rasterize utility).
+      #
+      # @see GDAL::Utils::Rasterize
+      # @see https://gdal.org/programs/gdal_rasterize.html gdal_rasterize utility documentation.
+      class Options
+        # @private
+        class AutoPointer < ::FFI::AutoPointer
+          # @param pointer [FFI::Pointer]
+          def self.release(pointer)
+            return unless pointer && !pointer.null?
+
+            ::FFI::GDAL::Utils.GDALRasterizeOptionsFree(pointer)
+          end
+        end
+
+        # @return [AutoPointer] C pointer to the GDALRasterizeOptions.
+        attr_reader :c_pointer
+
+        # @return [Array<String>] The options.
+        attr_reader :options
+
+        # Create a new instance.
+        #
+        # @see https://gdal.org/programs/gdal_rasterize.html
+        #   List of available options could be found in gdal_rasterize utility documentation.
+        #
+        # @example Create a new instance.
+        #  options = GDAL::Utils::Rasterize::Options.new(options: ["-of", "GTiff", "-ts", "10", "10"])
+        #
+        # @param options [Array<String>] The options list.
+        def initialize(options: [])
+          @options = options
+          @string_list = ::GDAL::Utils::Helpers::StringList.new(strings: options)
+          @c_pointer = AutoPointer.new(options_pointer)
+        end
+
+        private
+
+        attr_reader :string_list
+
+        def options_pointer
+          ::FFI::GDAL::Utils.GDALRasterizeOptionsNew(string_list.c_pointer, nil)
+        end
+      end
+    end
+  end
+end

--- a/lib/gdal/utils/translate.rb
+++ b/lib/gdal/utils/translate.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require_relative "translate/options"
+
+module GDAL
+  module Utils
+    # Wrapper for gdal_translate using GDALTranslate C API.
+    #
+    # @see https://gdal.org/programs/gdal_translate.html gdal_translate utility documentation.
+    # @see https://gdal.org/api/gdal_utils.html#gdal__utils_8h_1a1cf5b30de14ccaf847ae7a77bb546b28 GDALTranslate C API.
+    class Translate
+      # Perform the gdal_translate (GDALTranslate) operation.
+      #
+      # @example Translate a dataset.
+      #   src_dataset = GDAL::Dataset.open("source.tif", "r")
+      #   dataset = GDAL::Utils::Translate.perform(dst_dataset_path: "destination.tif", src_dataset: src_dataset)
+      #
+      #   # Do something with the dataset.
+      #   puts dataset.raster_x_size
+      #
+      #   # You must close the dataset when you are done with it.
+      #   dataset.close
+      #   src_dataset.close
+      #
+      # @example Translate a dataset with options.
+      #   src_dataset = GDAL::Dataset.open("source.tif", "r")
+      #   dataset = GDAL::Utils::Translate.perform(
+      #     dst_dataset_path: "destination.tif",
+      #     src_dataset: src_dataset,
+      #     options: GDAL::Utils::Translate::Options.new(options: ["-of", "GTiff", "-co", "COMPRESS=DEFLATE"])
+      #   )
+      #
+      #   # Do something with the dataset.
+      #   puts dataset.raster_x_size
+      #
+      #   # You must close the dataset when you are done with it.
+      #   dataset.close
+      #   src_dataset.close
+      #
+      # @example Translate a dataset using block syntax.
+      #   src_dataset = GDAL::Dataset.open("source.tif", "r")
+      #   GDAL::Utils::Translate.perform(dst_dataset_path: "destination.tif", src_dataset: src_dataset) do |dataset|
+      #     # Do something with the dataset.
+      #     puts dataset.raster_x_size
+      #
+      #     # Dataset will be closed automatically.
+      #   end
+      #   src_dataset.close
+      #
+      # @param dst_dataset_path [String] The path to the destination dataset.
+      # @param src_dataset [GDAL::Dataset] The source dataset.
+      # @param options [GDAL::Utils::Translate::Options] Options.
+      # @yield [GDAL::Dataset] The destination dataset.
+      # @return [GDAL::Dataset] The destination dataset (only if block is not specified; dataset must be closed).
+      # @raise [GDAL::Error] If the operation fails.
+      def self.perform(dst_dataset_path:, src_dataset:, options: Options.new, &block)
+        result_code_ptr = ::FFI::MemoryPointer.new(:int)
+        dst_dataset_ptr = ::FFI::GDAL::Utils.GDALTranslate(
+          dst_dataset_path,
+          src_dataset.c_pointer,
+          options.c_pointer,
+          result_code_ptr
+        )
+        success = result_code_ptr.read_int.zero?
+
+        raise ::GDAL::Error, "GDALTranslate failed." if dst_dataset_ptr.null? || !success
+
+        ::GDAL::Dataset.open(dst_dataset_ptr, "w", &block)
+      end
+    end
+  end
+end

--- a/lib/gdal/utils/translate/options.rb
+++ b/lib/gdal/utils/translate/options.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module GDAL
+  module Utils
+    class Translate
+      # Ruby wrapper for GDALTranslateOptions C API (options for gdal_translate utility).
+      #
+      # @see GDAL::Utils::Translate
+      # @see https://gdal.org/programs/gdal_translate.html gdal_translate utility documentation.
+      class Options
+        # @private
+        class AutoPointer < ::FFI::AutoPointer
+          # @param pointer [FFI::Pointer]
+          def self.release(pointer)
+            return unless pointer && !pointer.null?
+
+            ::FFI::GDAL::Utils.GDALTranslateOptionsFree(pointer)
+          end
+        end
+
+        # @return [AutoPointer] C pointer to the GDALTranslateOptions.
+        attr_reader :c_pointer
+
+        # @return [Array<String>] The options.
+        attr_reader :options
+
+        # Create a new instance.
+        #
+        # @see https://gdal.org/programs/gdal_translate.html
+        #   List of available options could be found in gdal_translate utility documentation.
+        #
+        # @example Create a new instance.
+        #  options = GDAL::Utils::Translate::Options.new(options: ["-of", "GTiff", "-co", "COMPRESS=DEFLATE"])
+        #
+        # @param options [Array<String>] The options list.
+        def initialize(options: [])
+          @options = options
+          @string_list = ::GDAL::Utils::Helpers::StringList.new(strings: options)
+          @c_pointer = AutoPointer.new(options_pointer)
+        end
+
+        private
+
+        attr_reader :string_list
+
+        def options_pointer
+          ::FFI::GDAL::Utils.GDALTranslateOptionsNew(string_list.c_pointer, nil)
+        end
+      end
+    end
+  end
+end

--- a/lib/gdal/utils/vector_translate.rb
+++ b/lib/gdal/utils/vector_translate.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require_relative "vector_translate/options"
+
+module GDAL
+  module Utils
+    # Wrapper for ogr2ogr using GDALVectorTranslate C API.
+    #
+    # @see https://gdal.org/programs/ogr2ogr.html ogr2ogr utility documentation.
+    # @see https://gdal.org/api/gdal_utils.html#_CPPv419GDALVectorTranslatePKc12GDALDatasetHiP12GDALDatasetHPK26GDALVectorTranslateOptionsPi
+    #   GDALVectorTranslate C API.
+    class VectorTranslate
+      # Perform the ogr2ogr (GDALVectorTranslate) operation.
+      #
+      # @example Translate a vector dataset (for dst_dataset_path).
+      #   src_dataset = OGR::DataSource.open("source.shp", "r")
+      #   dataset = GDAL::Utils::VectorTranslate.perform(
+      #     dst_dataset_path: "destination.geojson",
+      #     src_datasets: [src_dataset]
+      #   )
+      #
+      #   # Do something with the dataset.
+      #   puts dataset.layer(0).name
+      #
+      #   # You must close the dataset when you are done with it.
+      #   dataset.close
+      #   src_dataset.close
+      #
+      # @example Translate a vector dataset with options (for dst_dataset_path).
+      #   src_dataset = OGR::DataSource.open("source.shp", "r")
+      #   dataset = GDAL::Utils::VectorTranslate.perform(
+      #     dst_dataset_path: "destination.geojson",
+      #     src_datasets: [src_dataset],
+      #     options: GDAL::Utils::VectorTranslate::Options.new(options: ["-nlt", "MULTIPOLYGON"])
+      #   )
+      #
+      #   # Do something with the dataset.
+      #   puts dataset.layer(0).name
+      #
+      #   # You must close the dataset when you are done with it.
+      #   dataset.close
+      #   src_dataset.close
+      #
+      # @example Translate a vector dataset using block syntax (for dst_dataset_path).
+      #   src_dataset = OGR::DataSource.open("source.shp", "r")
+      #   GDAL::Utils::VectorTranslate.perform(
+      #     dst_dataset_path: "destination.geojson",
+      #     src_datasets: [src_dataset]
+      #   ) do |dataset|
+      #     # Do something with the dataset.
+      #     puts dataset.layer(0).name
+      #
+      #     # Dataset will be closed automatically.
+      #   end
+      #   src_dataset.close
+      #
+      # @example Translate a vector dataset (for dst_dataset).
+      #   src_dataset = OGR::DataSource.open("source.shp", "r")
+      #   dst_dataset = OGR::DataSource.open("destination.geojson", "w")
+      #
+      #   GDAL::Utils::VectorTranslate.perform(dst_dataset: dst_dataset, src_datasets: [src_dataset])
+      #
+      #   # You must close the dataset when you are done with it.
+      #   dst_dataset.close
+      #   src_dataset.close
+      #
+      # @example Translate a vector dataset with options (for dst_dataset).
+      #   src_dataset = OGR::DataSource.open("source.shp", "r")
+      #   dst_dataset = OGR::DataSource.open("destination.geojson", "w")
+      #
+      #   GDAL::Utils::VectorTranslate.perform(
+      #     dst_dataset: dst_dataset,
+      #     src_datasets: [src_dataset],
+      #     options: GDAL::Utils::VectorTranslate::Options.new(options: ["-nlt", "MULTIPOLYGON"])
+      #   )
+      #
+      #   # You must close the dataset when you are done with it.
+      #   dst_dataset.close
+      #   src_dataset.close
+      #
+      # @param dst_dataset_path [String] The path to the destination dataset.
+      # @param dst_dataset [OGR::DataSource] The destination dataset.
+      # @param src_datasets [Array<OGR::DataSource>] The source datasets.
+      # @param options [GDAL::Utils::VectorTranslate::Options] Options.
+      # @yield [OGR::DataSource] The destination dataset.
+      # @return [OGR::DataSource] The destination dataset (only if block is not specified; dataset must be closed).
+      def self.perform(dst_dataset: nil, dst_dataset_path: nil, src_datasets: [], options: Options.new, &block)
+        if dst_dataset
+          for_dataset(dst_dataset: dst_dataset, src_datasets: src_datasets, options: options)
+        else
+          for_dataset_path(dst_dataset_path: dst_dataset_path, src_datasets: src_datasets, options: options, &block)
+        end
+      end
+
+      def self.for_dataset(dst_dataset:, src_datasets: [], options: Options.new)
+        result_dataset_ptr(dst_dataset: dst_dataset, src_datasets: src_datasets, options: options)
+
+        # Return the input dataset as the output dataset (dataset is modified in place).
+        dst_dataset
+      end
+      private_class_method :for_dataset
+
+      def self.for_dataset_path(dst_dataset_path:, src_datasets: [], options: Options.new, &block)
+        dst_dataset_ptr = result_dataset_ptr(
+          dst_dataset_path: dst_dataset_path, src_datasets: src_datasets, options: options
+        )
+
+        ::OGR::DataSource.open(dst_dataset_ptr, "w", &block)
+      end
+      private_class_method :for_dataset_path
+
+      def self.result_dataset_ptr(dst_dataset_path: nil, dst_dataset: nil, src_datasets: [], options: Options.new)
+        src_dataset_list = ::GDAL::Utils::Helpers::DatasetList.new(datasets: src_datasets)
+        result_code_ptr = ::FFI::MemoryPointer.new(:int)
+        dst_dataset_ptr = ::FFI::GDAL::Utils.GDALVectorTranslate(
+          dst_dataset_path,
+          dst_dataset&.c_pointer,
+          src_dataset_list.count,
+          src_dataset_list.c_pointer,
+          options.c_pointer,
+          result_code_ptr
+        )
+        success = result_code_ptr.read_int.zero?
+
+        raise ::GDAL::Error, "GDALVectorTranslate failed." if dst_dataset_ptr.null? || !success
+
+        dst_dataset_ptr
+      end
+      private_class_method :result_dataset_ptr
+    end
+  end
+end

--- a/lib/gdal/utils/vector_translate/options.rb
+++ b/lib/gdal/utils/vector_translate/options.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module GDAL
+  module Utils
+    class VectorTranslate
+      # Ruby wrapper for GDALVectorTranslateOptions C API (options for ogr2ogr utility).
+      #
+      # @see GDAL::Utils::VectorTranslate
+      # @see https://gdal.org/programs/ogr2ogr.html ogr2ogr utility documentation.
+      class Options
+        # @private
+        class AutoPointer < ::FFI::AutoPointer
+          # @param pointer [FFI::Pointer]
+          def self.release(pointer)
+            return unless pointer && !pointer.null?
+
+            ::FFI::GDAL::Utils.GDALVectorTranslateOptionsFree(pointer)
+          end
+        end
+
+        # @return [AutoPointer] C pointer to the GDALVectorTranslateOptions.
+        attr_reader :c_pointer
+
+        # @return [Array<String>] The options.
+        attr_reader :options
+
+        # Create a new instance.
+        #
+        # @see https://gdal.org/programs/ogr2ogr.html
+        #   List of available options could be found in ogr2ogr utility documentation.
+        #
+        # @example Create a new instance.
+        #  options = GDAL::Utils::VectorTranslate::Options.new(options: ["-overwrite", "-nlt", "MULTIPOLYGON"])
+        #
+        # @param options [Array<String>] The options list.
+        def initialize(options: [])
+          @options = options
+          @string_list = ::GDAL::Utils::Helpers::StringList.new(strings: options)
+          @c_pointer = AutoPointer.new(options_pointer)
+        end
+
+        private
+
+        attr_reader :string_list
+
+        def options_pointer
+          ::FFI::GDAL::Utils.GDALVectorTranslateOptionsNew(string_list.c_pointer, nil)
+        end
+      end
+    end
+  end
+end

--- a/lib/gdal/utils/warp.rb
+++ b/lib/gdal/utils/warp.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require_relative "warp/options"
+
+module GDAL
+  module Utils
+    # Wrapper for gdalwarp using GDALWarp C API.
+    #
+    # @see https://gdal.org/programs/gdalwarp.html gdalwarp utility documentation.
+    # @see https://gdal.org/api/gdal_utils.html#_CPPv48GDALWarpPKc12GDALDatasetHiP12GDALDatasetHPK18GDALWarpAppOptionsPi
+    #   GDALWarp C API.
+    class Warp
+      # Perform the gdalwarp (GDALWarp) operation.
+      #
+      # @example Warp a dataset (for dst_dataset_path).
+      #   src_dataset = GDAL::Dataset.open("source.tif", "r")
+      #   options = GDAL::Utils::Warp::Options.new(options: ["-t_srs", "EPSG:3857"])
+      #
+      #   dataset = GDAL::Utils::Warp.perform(
+      #     dst_dataset_path: "destination.tif",
+      #     src_datasets: [src_dataset],
+      #     options: options
+      #   )
+      #
+      #   # Do something with the dataset.
+      #   puts dataset.raster_x_size
+      #
+      #   # You must close the dataset when you are done with it.
+      #   dataset.close
+      #   src_dataset.close
+      #
+      # @example Warp a dataset (for dst_dataset_path) using block syntax.
+      #   src_dataset = GDAL::Dataset.open("source.tif", "r")
+      #   options = GDAL::Utils::Warp::Options.new(options: ["-t_srs", "EPSG:3857"])
+      #
+      #   GDAL::Utils::Warp.perform(
+      #     dst_dataset_path: "destination.tif",
+      #     src_datasets: src_dataset,
+      #     options: options
+      #   ) do |dataset|
+      #     # Do something with the dataset.
+      #     puts dataset.raster_x_size
+      #
+      #     # Dataset will be closed automatically.
+      #   end
+      #   src_dataset.close
+      #
+      # @example Warp a dataset (for dst_dataset).
+      #   src_dataset = GDAL::Dataset.open("source.tif", "r")
+      #   dst_dataset = GDAL::Dataset.open("destination.tif", "w") # Dataset with other projection.
+      #
+      #   GDAL::Utils::Warp.perform(dst_dataset: dst_dataset, src_datasets: [src_dataset])
+      #
+      #   # You must close the dataset when you are done with it.
+      #   dst_dataset.close
+      #   src_dataset.close
+      #
+      # @param dst_dataset_path [String] The path to the destination dataset.
+      # @param dst_dataset [GDAL::Dataset] The destination dataset.
+      # @param src_datasets [Array<GDAL::Dataset>] The source datasets.
+      # @param options [GDAL::Utils::Warp::Options] Options.
+      # @yield [GDAL::Dataset] The destination dataset.
+      # @return [GDAL::Dataset] The destination dataset (only if block is not specified; dataset must be closed).
+      def self.perform(dst_dataset: nil, dst_dataset_path: nil, src_datasets: [], options: Options.new, &block)
+        if dst_dataset
+          for_dataset(dst_dataset: dst_dataset, src_datasets: src_datasets, options: options)
+        else
+          for_dataset_path(dst_dataset_path: dst_dataset_path, src_datasets: src_datasets, options: options, &block)
+        end
+      end
+
+      # @param dst_dataset [GDAL::Dataset] The destination dataset.
+      # @param src_datasets [Array<GDAL::Dataset>] The source datasets.
+      # @param options [GDAL::Utils::Warp::Options] Options.
+      # @return [GDAL::Dataset] The destination dataset (it's the same object as dst_dataset).
+      def self.for_dataset(dst_dataset:, src_datasets: [], options: Options.new)
+        result_dataset_ptr(dst_dataset: dst_dataset, src_datasets: src_datasets, options: options)
+
+        # Return the input dataset as the output dataset (dataset is modified in place).
+        dst_dataset
+      end
+      private_class_method :for_dataset
+
+      # @param dst_dataset_path [String] The path to the destination dataset.
+      # @param src_datasets [Array<GDAL::Dataset>] The source datasets.
+      # @param options [GDAL::Utils::Warp::Options] Options.
+      # @yield [GDAL::Dataset] The destination dataset.
+      # @return [GDAL::Dataset] The destination dataset (only if block is not specified; dataset must be closed).
+      def self.for_dataset_path(dst_dataset_path:, src_datasets: [], options: Options.new, &block)
+        dst_dataset_ptr = result_dataset_ptr(
+          dst_dataset_path: dst_dataset_path, src_datasets: src_datasets, options: options
+        )
+
+        ::GDAL::Dataset.open(dst_dataset_ptr, "w", &block)
+      end
+      private_class_method :for_dataset_path
+
+      def self.result_dataset_ptr(dst_dataset_path: nil, dst_dataset: nil, src_datasets: [], options: Options.new)
+        src_dataset_list = ::GDAL::Utils::Helpers::DatasetList.new(datasets: src_datasets)
+        result_code_ptr = ::FFI::MemoryPointer.new(:int)
+        dst_dataset_ptr = ::FFI::GDAL::Utils.GDALWarp(
+          dst_dataset_path,
+          dst_dataset&.c_pointer,
+          src_dataset_list.count,
+          src_dataset_list.c_pointer,
+          options.c_pointer,
+          result_code_ptr
+        )
+        success = result_code_ptr.read_int.zero?
+
+        raise ::GDAL::Error, "GDALWarp failed." if dst_dataset_ptr.null? || !success
+
+        dst_dataset_ptr
+      end
+      private_class_method :result_dataset_ptr
+    end
+  end
+end

--- a/lib/gdal/utils/warp/options.rb
+++ b/lib/gdal/utils/warp/options.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module GDAL
+  module Utils
+    class Warp
+      # Ruby wrapper for GDALWarpAppOptions C API (options for ogr2ogr utility).
+      #
+      # @see GDAL::Utils::Warp
+      # @see https://gdal.org/programs/gdalwarp.html gdalwarp utility documentation.
+      class Options
+        # @private
+        class AutoPointer < ::FFI::AutoPointer
+          # @param pointer [FFI::Pointer]
+          def self.release(pointer)
+            return unless pointer && !pointer.null?
+
+            ::FFI::GDAL::Utils.GDALWarpAppOptionsFree(pointer)
+          end
+        end
+
+        # @return [AutoPointer] C pointer to the GDALWarpAppOptions.
+        attr_reader :c_pointer
+
+        # @return [Array<String>] The options.
+        attr_reader :options
+
+        # Create a new instance.
+        #
+        # @see https://gdal.org/programs/gdalwarp.html
+        #   List of available options could be found in gdalwarp utility documentation.
+        #
+        # @example Create a new instance.
+        #  options = GDAL::Utils::Warp::Options.new(options: ["-multi", "-wo", "CUTLINE_ALL_TOUCHED=TRUE"])
+        #
+        # @param options [Array<String>] The options list.
+        def initialize(options: [])
+          @options = options
+          @string_list = ::GDAL::Utils::Helpers::StringList.new(strings: options)
+          @c_pointer = AutoPointer.new(options_pointer)
+        end
+
+        private
+
+        attr_reader :string_list
+
+        def options_pointer
+          ::FFI::GDAL::Utils.GDALWarpAppOptionsNew(string_list.c_pointer, nil)
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ end
 $LOAD_PATH.unshift File.expand_path("lib", __dir__)
 require "ffi-gdal"
 require "byebug"
+require "securerandom"
 
 Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
 

--- a/spec/unit/gdal/utils/dem/options_spec.rb
+++ b/spec/unit/gdal/utils/dem/options_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "gdal"
+
+RSpec.describe GDAL::Utils::DEM::Options do
+  context "when no options are provided" do
+    it "returns a new instance of Options" do
+      subject { described_class.new }
+
+      expect(subject).to be_a(described_class)
+      expect(subject.c_pointer).to be_a(described_class::AutoPointer)
+      expect(subject.c_pointer).not_to be_null
+    end
+  end
+
+  context "when options are provided" do
+    subject { described_class.new(options: options) }
+
+    let(:options) { ["-of", "GTiff", "-co", "COMPRESS=DEFLATE"] }
+
+    it "returns a new instance of Options with options" do
+      expect(subject).to be_a(described_class)
+      expect(subject.c_pointer).to be_a(described_class::AutoPointer)
+      expect(subject.c_pointer).not_to be_null
+    end
+  end
+
+  context "when incorrect options are provided" do
+    subject { described_class.new(options: options) }
+
+    let(:options) { ["-unknown123"] }
+
+    it "raises exception" do
+      expect { subject }.to raise_exception(
+        GDAL::UnsupportedOperation, "Unknown option name '-unknown123'"
+      )
+    end
+  end
+end

--- a/spec/unit/gdal/utils/dem_spec.rb
+++ b/spec/unit/gdal/utils/dem_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "gdal"
+
+RSpec.describe GDAL::Utils::DEM do
+  let(:src_dataset_path) do
+    path = "../../../../spec/support/images/osgeo/geotiff/GeogToWGS84GeoKey/GeogToWGS84GeoKey5.tif"
+    File.expand_path(path, __dir__)
+  end
+
+  let(:src_dataset) { GDAL::Dataset.open(src_dataset_path, "r") }
+  after { src_dataset.close }
+
+  describe ".perform" do
+    let(:new_dataset_path) { "/vsimem/test-#{SecureRandom.uuid}.tif" }
+
+    context "when no options are provided" do
+      it "returns new dataset" do
+        new_dataset = described_class.perform(
+          dst_dataset_path: new_dataset_path,
+          src_dataset: src_dataset,
+          processing: "hillshade"
+        )
+
+        expect(new_dataset).to be_a(GDAL::Dataset)
+        expect(GDAL::Utils::Info.perform(dataset: new_dataset)).not_to include("Block=256x256")
+
+        new_dataset.close
+      end
+
+      it "returns new dataset in block" do
+        described_class.perform(
+          dst_dataset_path: new_dataset_path,
+          src_dataset: src_dataset,
+          processing: "hillshade"
+        ) do |new_dataset|
+          expect(new_dataset).to be_a(GDAL::Dataset)
+        end
+      end
+    end
+
+    context "when options are provided" do
+      it "returns new dataset with options applied" do
+        options = GDAL::Utils::DEM::Options.new(options: ["-of", "GTiff", "-co", "TILED=YES"])
+
+        new_dataset = described_class.perform(
+          dst_dataset_path: new_dataset_path, src_dataset: src_dataset, processing: "hillshade", options: options
+        )
+
+        expect(new_dataset).to be_a(GDAL::Dataset)
+        expect(GDAL::Utils::Info.perform(dataset: new_dataset)).to include("Block=256x256")
+
+        new_dataset.close
+      end
+    end
+
+    context "when operation fails with GDAL internal exception" do
+      it "raises exception" do
+        expect do
+          described_class.perform(
+            dst_dataset_path: new_dataset_path,
+            src_dataset: src_dataset,
+            processing: "hillshade123"
+          )
+        end.to raise_exception(
+          ArgumentError, "Invalid processing"
+        )
+      end
+
+      it "raises exception" do
+        options = GDAL::Utils::DEM::Options.new(options: ["-b", "100"])
+
+        expect do
+          described_class.perform(
+            dst_dataset_path: new_dataset_path,
+            src_dataset: src_dataset,
+            processing: "hillshade",
+            options: options
+          )
+        end.to raise_exception(
+          ArgumentError, "Unable to fetch band #100"
+        )
+      end
+    end
+
+    context "color-relief" do
+      it "returns new dataset with color-relief applied" do
+        Tempfile.create(["color", ".txt"]) do |color_file|
+          color_file.write("0 255 0 0\n1 0 255 0\n2 0 0 255")
+          color_file.flush
+
+          new_dataset = described_class.perform(
+            dst_dataset_path: new_dataset_path,
+            src_dataset: src_dataset,
+            processing: "color-relief",
+            color_filename: color_file.path
+          )
+
+          expect(new_dataset).to be_a(GDAL::Dataset)
+          expect(GDAL::Utils::Info.perform(dataset: new_dataset)).not_to include("COMPRESSION=DEFLATE")
+
+          new_dataset.close
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/gdal/utils/grid/options_spec.rb
+++ b/spec/unit/gdal/utils/grid/options_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "gdal"
+
+RSpec.describe GDAL::Utils::Grid::Options do
+  context "when no options are provided" do
+    it "returns a new instance of Options" do
+      subject { described_class.new }
+
+      expect(subject).to be_a(described_class)
+      expect(subject.c_pointer).to be_a(described_class::AutoPointer)
+      expect(subject.c_pointer).not_to be_null
+    end
+  end
+
+  context "when options are provided" do
+    subject { described_class.new(options: options) }
+
+    let(:options) { ["-of", "GTiff", "-outsize", "10", "10"] }
+
+    it "returns a new instance of Options with options" do
+      expect(subject).to be_a(described_class)
+      expect(subject.c_pointer).to be_a(described_class::AutoPointer)
+      expect(subject.c_pointer).not_to be_null
+    end
+  end
+
+  context "when incorrect options are provided" do
+    subject { described_class.new(options: options) }
+
+    let(:options) { ["-unknown123"] }
+
+    it "raises exception" do
+      expect { subject }.to raise_exception(
+        GDAL::UnsupportedOperation, "Unknown option name '-unknown123'"
+      )
+    end
+  end
+end

--- a/spec/unit/gdal/utils/grid_spec.rb
+++ b/spec/unit/gdal/utils/grid_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "gdal"
+require "ogr"
+
+RSpec.describe GDAL::Utils::Grid do
+  let(:src_dataset_path) do
+    path = "../../../../spec/support/shapefiles/states_21basic/states.shp"
+    File.expand_path(path, __dir__)
+  end
+
+  let(:src_dataset) { OGR::DataSource.open(src_dataset_path, "r") }
+  after { src_dataset.close }
+
+  describe ".perform" do
+    let(:new_dataset_path) { "/vsimem/test-#{SecureRandom.uuid}.tif" }
+
+    context "when no options are provided" do
+      it "returns new dataset" do
+        new_dataset = described_class.perform(dst_dataset_path: new_dataset_path, src_dataset: src_dataset)
+
+        expect(new_dataset).to be_a(GDAL::Dataset)
+
+        new_dataset.close
+      end
+    end
+
+    context "when options are provided" do
+      it "returns new dataset with options applied" do
+        options = GDAL::Utils::Grid::Options.new(options: ["-outsize", "10", "10"])
+
+        new_dataset = described_class.perform(
+          dst_dataset_path: new_dataset_path, src_dataset: src_dataset, options: options
+        )
+
+        expect(new_dataset).to be_a(GDAL::Dataset)
+        expect(GDAL::Utils::Info.perform(dataset: new_dataset)).to include("Size is 10, 10")
+
+        new_dataset.close
+      end
+
+      it "returns new dataset in block" do
+        options = GDAL::Utils::Grid::Options.new(options: ["-outsize", "10", "10"])
+
+        described_class.perform(
+          dst_dataset_path: new_dataset_path,
+          src_dataset: src_dataset,
+          options: options
+        ) do |new_dataset|
+          expect(new_dataset).to be_a(GDAL::Dataset)
+          expect(GDAL::Utils::Info.perform(dataset: new_dataset)).to include("Size is 10, 10")
+        end
+      end
+    end
+
+    context "when operation fails with GDAL internal exception" do
+      it "raises exception" do
+        options = GDAL::Utils::Grid::Options.new(options: ["-of", "UnknownFormat123"])
+
+        expect do
+          described_class.perform(dst_dataset_path: new_dataset_path, src_dataset: src_dataset, options: options)
+        end.to raise_exception(
+          GDAL::Error, /Output driver `UnknownFormat123' not recognised/
+        )
+      end
+    end
+  end
+end

--- a/spec/unit/gdal/utils/helpers/dataset_list_spec.rb
+++ b/spec/unit/gdal/utils/helpers/dataset_list_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "gdal"
+
+RSpec.describe GDAL::Utils::Helpers::DatasetList do
+  context "when no datasets are provided" do
+    subject { described_class.new }
+
+    it "returns a new instance of DatasetList" do
+      expect(subject).to be_a(described_class)
+      expect(subject.datasets).to eq([])
+      expect(subject.c_pointer).to be_a(FFI::MemoryPointer)
+    end
+  end
+
+  context "when datasets are provided" do
+    subject { described_class.new(datasets: datasets) }
+
+    let(:driver) { GDAL::Driver.by_name("GTiff") }
+
+    let(:datasets) do
+      [
+        driver.create_dataset("/vsimem/example1.tif", 10, 10),
+        driver.create_dataset("/vsimem/example2.tif", 10, 10)
+      ]
+    end
+
+    after { datasets.each(&:close) }
+
+    it "returns a new instance of DatasetList with options" do
+      expect(subject).to be_a(described_class)
+      expect(subject.datasets).to eq(datasets)
+      expect(subject.c_pointer).to be_a(FFI::MemoryPointer)
+    end
+  end
+end

--- a/spec/unit/gdal/utils/helpers/string_list_spec.rb
+++ b/spec/unit/gdal/utils/helpers/string_list_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "gdal"
+
+RSpec.describe GDAL::Utils::Helpers::StringList do
+  context "when no strings are provided" do
+    subject { described_class.new }
+
+    it "returns a new instance of StringList" do
+      expect(subject).to be_a(described_class)
+      expect(subject.c_pointer).to be_a(described_class::AutoPointer)
+      expect(subject.c_pointer).to be_null
+    end
+  end
+
+  context "when strings are provided" do
+    subject { described_class.new(strings: strings) }
+
+    let(:strings) { ["-option1", "-option2"] }
+
+    it "returns a new instance of StringList with options" do
+      expect(subject).to be_a(described_class)
+      expect(subject.c_pointer).to be_a(described_class::AutoPointer)
+      expect(subject.c_pointer).not_to be_null
+    end
+  end
+end

--- a/spec/unit/gdal/utils/info/options_spec.rb
+++ b/spec/unit/gdal/utils/info/options_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "gdal"
+
+RSpec.describe GDAL::Utils::Info::Options do
+  context "when no options are provided" do
+    it "returns a new instance of Options" do
+      subject { described_class.new }
+
+      expect(subject).to be_a(described_class)
+      expect(subject.c_pointer).to be_a(described_class::AutoPointer)
+      expect(subject.c_pointer).not_to be_null
+    end
+  end
+
+  context "when options are provided" do
+    subject { described_class.new(options: options) }
+
+    let(:options) { ["-json", "-mdd", "all"] }
+
+    it "returns a new instance of Options with options" do
+      expect(subject).to be_a(described_class)
+      expect(subject.c_pointer).to be_a(described_class::AutoPointer)
+      expect(subject.c_pointer).not_to be_null
+    end
+  end
+
+  context "when incorrect options are provided" do
+    subject { described_class.new(options: options) }
+
+    let(:options) { ["-json123"] }
+
+    it "raises exception" do
+      expect { subject }.to raise_exception(
+        GDAL::UnsupportedOperation, "Unknown option name '-json123'"
+      )
+    end
+  end
+end

--- a/spec/unit/gdal/utils/info_spec.rb
+++ b/spec/unit/gdal/utils/info_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "gdal"
+
+RSpec.describe GDAL::Utils::Info do
+  let(:src_dataset_path) do
+    path = "../../../../spec/support/images/osgeo/geotiff/GeogToWGS84GeoKey/GeogToWGS84GeoKey5.tif"
+    File.expand_path(path, __dir__)
+  end
+
+  let(:dataset) { GDAL::Dataset.open(src_dataset_path, "r") }
+  after { dataset.close }
+
+  describe ".perform" do
+    context "when no options are provided" do
+      it "returns GDALInfo text" do
+        expect(described_class.perform(dataset: dataset)).to include("Driver: GTiff/GeoTIFF")
+      end
+    end
+
+    context "when options are provided" do
+      it "returns GDALInfo text with options applied" do
+        options = GDAL::Utils::Info::Options.new(options: ["-json"])
+        parsed_result = JSON.parse(described_class.perform(dataset: dataset, options: options))
+        expect(parsed_result).to include(
+          {
+            "driverShortName" => "GTiff",
+            "driverLongName" => "GeoTIFF",
+            "size" => [101, 101]
+          }
+        )
+      end
+    end
+  end
+end

--- a/spec/unit/gdal/utils/nearblack/options_spec.rb
+++ b/spec/unit/gdal/utils/nearblack/options_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "gdal"
+
+RSpec.describe GDAL::Utils::Nearblack::Options do
+  context "when no options are provided" do
+    it "returns a new instance of Options" do
+      subject { described_class.new }
+
+      expect(subject).to be_a(described_class)
+      expect(subject.c_pointer).to be_a(described_class::AutoPointer)
+      expect(subject.c_pointer).not_to be_null
+    end
+  end
+
+  context "when options are provided" do
+    subject { described_class.new(options: options) }
+
+    let(:options) { ["-of", "GTiff", "-near", "10"] }
+
+    it "returns a new instance of Options with options" do
+      expect(subject).to be_a(described_class)
+      expect(subject.c_pointer).to be_a(described_class::AutoPointer)
+      expect(subject.c_pointer).not_to be_null
+    end
+  end
+
+  context "when incorrect options are provided" do
+    subject { described_class.new(options: options) }
+
+    let(:options) { ["-unknown123"] }
+
+    it "raises exception" do
+      expect { subject }.to raise_exception(
+        GDAL::UnsupportedOperation, "Unknown option name '-unknown123'"
+      )
+    end
+  end
+end

--- a/spec/unit/gdal/utils/nearblack_spec.rb
+++ b/spec/unit/gdal/utils/nearblack_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "gdal"
+
+RSpec.describe GDAL::Utils::Nearblack do
+  let(:src_dataset_path) do
+    path = "../../../../spec/support/images/osgeo/geotiff/GeogToWGS84GeoKey/GeogToWGS84GeoKey5.tif"
+    File.expand_path(path, __dir__)
+  end
+
+  let(:src_dataset) { GDAL::Dataset.open(src_dataset_path, "r") }
+  after { src_dataset.close }
+
+  describe ".perform" do
+    context "when dst_dataset_path used" do
+      let(:dst_dataset_path) { "/vsimem/test-#{SecureRandom.uuid}.tif" }
+
+      context "when no options are provided" do
+        it "returns new dataset" do
+          new_dataset = described_class.perform(dst_dataset_path: dst_dataset_path, src_dataset: src_dataset)
+
+          expect(new_dataset).to be_a(GDAL::Dataset)
+          expect(GDAL::Utils::Info.perform(dataset: new_dataset)).not_to include("Block=256x256")
+
+          new_dataset.close
+        end
+
+        it "returns new dataset in block" do
+          described_class.perform(dst_dataset_path: dst_dataset_path, src_dataset: src_dataset) do |new_dataset|
+            expect(new_dataset).to be_a(GDAL::Dataset)
+          end
+        end
+      end
+
+      context "when options are provided" do
+        it "returns new dataset with options applied" do
+          options = GDAL::Utils::Nearblack::Options.new(options: ["-co", "TILED=YES", "-near", "10"])
+
+          new_dataset = described_class.perform(
+            dst_dataset_path: dst_dataset_path, src_dataset: src_dataset, options: options
+          )
+
+          expect(new_dataset).to be_a(GDAL::Dataset)
+          expect(GDAL::Utils::Info.perform(dataset: new_dataset)).to include("Block=256x256")
+
+          new_dataset.close
+        end
+      end
+
+      context "when operation fails without GDAL internal exception" do
+        it "raises exception" do
+          options = GDAL::Utils::Nearblack::Options.new(options: ["-of", "UnknownFormat123"])
+
+          expect do
+            described_class.perform(dst_dataset_path: dst_dataset_path, src_dataset: src_dataset, options: options)
+          end.to raise_exception(
+            GDAL::Error, "GDALNearblack failed."
+          )
+        end
+      end
+    end
+
+    context "when dst_dataset used" do
+      context "when no options are provided" do
+        it "returns dst_dataset with changes applied" do
+          dst_dataset_path = "/vsimem/test-#{SecureRandom.uuid}.tif"
+          dst_dataset = GDAL::Utils::Translate.perform(dst_dataset_path: dst_dataset_path, src_dataset: src_dataset)
+
+          result_dataset = described_class.perform(dst_dataset: dst_dataset, src_dataset: src_dataset)
+          expect(result_dataset).to eq(dst_dataset)
+
+          dst_dataset.close
+        end
+      end
+
+      context "when operation fails with GDAL internal exception" do
+        it "raises exception" do
+          dst_dataset_path = "/vsimem/test-#{SecureRandom.uuid}.tif"
+          dst_dataset = GDAL::Utils::Translate.perform(
+            dst_dataset_path: dst_dataset_path,
+            src_dataset: src_dataset,
+            options: GDAL::Utils::Translate::Options.new(options: ["-outsize", "50%", "50%"])
+          )
+
+          expect do
+            described_class.perform(dst_dataset: dst_dataset, src_dataset: src_dataset)
+          end.to raise_exception(
+            GDAL::Error, "The dimensions of the output dataset don't match the dimensions of the input dataset."
+          )
+
+          dst_dataset.close
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/gdal/utils/rasterize/options_spec.rb
+++ b/spec/unit/gdal/utils/rasterize/options_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "gdal"
+
+RSpec.describe GDAL::Utils::Rasterize::Options do
+  context "when no options are provided" do
+    it "returns a new instance of Options" do
+      subject { described_class.new }
+
+      expect(subject).to be_a(described_class)
+      expect(subject.c_pointer).to be_a(described_class::AutoPointer)
+      expect(subject.c_pointer).not_to be_null
+    end
+  end
+
+  context "when options are provided" do
+    subject { described_class.new(options: options) }
+
+    let(:options) { ["-of", "GTiff", "-ts", "10", "10"] }
+
+    it "returns a new instance of Options with options" do
+      expect(subject).to be_a(described_class)
+      expect(subject.c_pointer).to be_a(described_class::AutoPointer)
+      expect(subject.c_pointer).not_to be_null
+    end
+  end
+
+  context "when incorrect options are provided" do
+    subject { described_class.new(options: options) }
+
+    let(:options) { ["-unknown123"] }
+
+    it "raises exception" do
+      expect { subject }.to raise_exception(
+        GDAL::UnsupportedOperation, "Unknown option name '-unknown123'"
+      )
+    end
+  end
+end

--- a/spec/unit/gdal/utils/rasterize_spec.rb
+++ b/spec/unit/gdal/utils/rasterize_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "gdal"
+require "ogr"
+
+RSpec.describe GDAL::Utils::Rasterize do
+  let(:src_dataset_path) do
+    path = "../../../../spec/support/shapefiles/states_21basic/states.shp"
+    File.expand_path(path, __dir__)
+  end
+
+  let(:src_dataset) { OGR::DataSource.open(src_dataset_path, "r") }
+  after { src_dataset.close }
+
+  describe ".perform" do
+    let(:new_dataset_path) { "/vsimem/test-#{SecureRandom.uuid}.tif" }
+
+    context "when no options are provided" do
+      it "raises exceptions (size or resolution must be provided)" do
+        expect do
+          described_class.perform(dst_dataset_path: new_dataset_path, src_dataset: src_dataset)
+        end.to raise_exception(GDAL::Error, "Size and resolutions are missing")
+      end
+    end
+
+    context "when options are provided" do
+      it "returns new dataset with options applied" do
+        options = GDAL::Utils::Rasterize::Options.new(options: ["-ts", "10", "10"])
+
+        new_dataset = described_class.perform(
+          dst_dataset_path: new_dataset_path, src_dataset: src_dataset, options: options
+        )
+
+        expect(new_dataset).to be_a(GDAL::Dataset)
+        expect(GDAL::Utils::Info.perform(dataset: new_dataset)).to include("Size is 10, 10")
+
+        new_dataset.close
+      end
+
+      it "returns new dataset in block" do
+        options = GDAL::Utils::Rasterize::Options.new(options: ["-ts", "10", "10"])
+
+        described_class.perform(
+          dst_dataset_path: new_dataset_path,
+          src_dataset: src_dataset,
+          options: options
+        ) do |new_dataset|
+          expect(new_dataset).to be_a(GDAL::Dataset)
+          expect(GDAL::Utils::Info.perform(dataset: new_dataset)).to include("Size is 10, 10")
+        end
+      end
+    end
+
+    context "when operation fails with GDAL internal exception" do
+      it "raises exception" do
+        options = GDAL::Utils::Rasterize::Options.new(options: ["-ts", "10", "10", "-of", "UnknownFormat123"])
+
+        expect do
+          described_class.perform(dst_dataset_path: new_dataset_path, src_dataset: src_dataset, options: options)
+        end.to raise_exception(
+          GDAL::UnsupportedOperation, /Output driver `UnknownFormat123' not recognised/
+        )
+      end
+    end
+  end
+end

--- a/spec/unit/gdal/utils/translate/options_spec.rb
+++ b/spec/unit/gdal/utils/translate/options_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "gdal"
+
+RSpec.describe GDAL::Utils::Translate::Options do
+  context "when no options are provided" do
+    it "returns a new instance of Options" do
+      subject { described_class.new }
+
+      expect(subject).to be_a(described_class)
+      expect(subject.c_pointer).to be_a(described_class::AutoPointer)
+      expect(subject.c_pointer).not_to be_null
+    end
+  end
+
+  context "when options are provided" do
+    subject { described_class.new(options: options) }
+
+    let(:options) { ["-unscale", "-ot", "Byte"] }
+
+    it "returns a new instance of Options with options" do
+      expect(subject).to be_a(described_class)
+      expect(subject.c_pointer).to be_a(described_class::AutoPointer)
+      expect(subject.c_pointer).not_to be_null
+    end
+  end
+
+  context "when incorrect options are provided" do
+    subject { described_class.new(options: options) }
+
+    let(:options) { ["-unscale123"] }
+
+    it "raises exception" do
+      expect { subject }.to raise_exception(
+        GDAL::UnsupportedOperation, "Unknown option name '-unscale123'"
+      )
+    end
+  end
+end

--- a/spec/unit/gdal/utils/translate_spec.rb
+++ b/spec/unit/gdal/utils/translate_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "gdal"
+
+RSpec.describe GDAL::Utils::Translate do
+  let(:src_dataset_path) do
+    path = "../../../../spec/support/images/osgeo/geotiff/GeogToWGS84GeoKey/GeogToWGS84GeoKey5.tif"
+    File.expand_path(path, __dir__)
+  end
+
+  let(:src_dataset) { GDAL::Dataset.open(src_dataset_path, "r") }
+  after { src_dataset.close }
+
+  describe ".perform" do
+    let(:new_dataset_path) { "/vsimem/test-#{SecureRandom.uuid}.tif" }
+
+    context "when no options are provided" do
+      it "returns new dataset" do
+        new_dataset = described_class.perform(dst_dataset_path: new_dataset_path, src_dataset: src_dataset)
+
+        expect(new_dataset).to be_a(GDAL::Dataset)
+        expect(GDAL::Utils::Info.perform(dataset: new_dataset)).not_to include("COMPRESSION=DEFLATE")
+
+        new_dataset.close
+      end
+
+      it "returns new dataset in block" do
+        described_class.perform(dst_dataset_path: new_dataset_path, src_dataset: src_dataset) do |new_dataset|
+          expect(new_dataset).to be_a(GDAL::Dataset)
+        end
+      end
+    end
+
+    context "when options are provided" do
+      it "returns new dataset with options applied" do
+        options = GDAL::Utils::Translate::Options.new(options: ["-co", "COMPRESS=DEFLATE"])
+
+        new_dataset = described_class.perform(
+          dst_dataset_path: new_dataset_path, src_dataset: src_dataset, options: options
+        )
+
+        expect(new_dataset).to be_a(GDAL::Dataset)
+        expect(GDAL::Utils::Info.perform(dataset: new_dataset)).to include("COMPRESSION=DEFLATE")
+
+        new_dataset.close
+      end
+    end
+
+    context "when operation fails with GDAL internal exception" do
+      it "raises exception" do
+        options = GDAL::Utils::Translate::Options.new(options: ["-b", "100"])
+
+        expect do
+          described_class.perform(dst_dataset_path: new_dataset_path, src_dataset: src_dataset, options: options)
+        end.to raise_exception(
+          GDAL::Error, "Band 100 requested, but only bands 1 to 1 available."
+        )
+      end
+    end
+  end
+end

--- a/spec/unit/gdal/utils/vector_translate/options_spec.rb
+++ b/spec/unit/gdal/utils/vector_translate/options_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "gdal"
+
+RSpec.describe GDAL::Utils::VectorTranslate::Options do
+  context "when no options are provided" do
+    it "returns a new instance of Options" do
+      subject { described_class.new }
+
+      expect(subject).to be_a(described_class)
+      expect(subject.c_pointer).to be_a(described_class::AutoPointer)
+      expect(subject.c_pointer).not_to be_null
+    end
+  end
+
+  context "when options are provided" do
+    subject { described_class.new(options: options) }
+
+    let(:options) { ["-overwrite", "-nlt", "MULTIPOLYGON"] }
+
+    it "returns a new instance of Options with options" do
+      expect(subject).to be_a(described_class)
+      expect(subject.c_pointer).to be_a(described_class::AutoPointer)
+      expect(subject.c_pointer).not_to be_null
+    end
+  end
+
+  context "when incorrect options are provided" do
+    subject { described_class.new(options: options) }
+
+    let(:options) { ["-overwrite123"] }
+
+    it "raises exception" do
+      expect { subject }.to raise_exception(
+        GDAL::UnsupportedOperation, "Unknown option name '-overwrite123'"
+      )
+    end
+  end
+end

--- a/spec/unit/gdal/utils/vector_translate_spec.rb
+++ b/spec/unit/gdal/utils/vector_translate_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "gdal"
+require "ogr"
+
+RSpec.describe GDAL::Utils::VectorTranslate do
+  let(:src_dataset_path) do
+    path = "../../../../spec/support/shapefiles/states_21basic/states.shp"
+    File.expand_path(path, __dir__)
+  end
+
+  let(:src_dataset) { OGR::DataSource.open(src_dataset_path, "r") }
+  after { src_dataset.close }
+
+  describe ".perform" do
+    context "when dst_dataset_path used" do
+      let(:dst_dataset_path) { "/vsimem/test-#{SecureRandom.uuid}.geojson" }
+
+      context "when no options are provided" do
+        it "returns new dataset" do
+          new_dataset = described_class.perform(dst_dataset_path: dst_dataset_path, src_datasets: [src_dataset])
+
+          expect(new_dataset).to be_a(OGR::DataSource)
+          expect(new_dataset.driver.name).to eq("GeoJSON")
+          expect(new_dataset.layer(0).geometry_type).to eq(:wkbPolygon)
+
+          new_dataset.close
+        end
+
+        it "returns new dataset in block" do
+          described_class.perform(dst_dataset_path: dst_dataset_path, src_datasets: [src_dataset]) do |new_dataset|
+            expect(new_dataset).to be_a(OGR::DataSource)
+          end
+        end
+      end
+
+      context "when options are provided" do
+        it "returns new dataset with options applied" do
+          options = GDAL::Utils::VectorTranslate::Options.new(options: ["-nlt", "MULTIPOLYGON"])
+
+          new_dataset = described_class.perform(
+            dst_dataset_path: dst_dataset_path, src_datasets: [src_dataset], options: options
+          )
+
+          expect(new_dataset).to be_a(OGR::DataSource)
+          expect(new_dataset.layer(0).geometry_type).to eq(:wkbMultiPolygon)
+
+          new_dataset.close
+        end
+      end
+
+      context "when operation fails with GDAL internal exception" do
+        it "raises exception" do
+          expect do
+            described_class.perform(dst_dataset_path: dst_dataset_path, src_datasets: [])
+          end.to raise_exception(
+            GDAL::Error, "nSrcCount != 1"
+          )
+        end
+      end
+    end
+
+    context "when dst_dataset used" do
+      let(:dst_dataset) do
+        OGR::Driver.by_name("GeoJSON").create_data_source("/vsimem/test-#{SecureRandom.uuid}.geojson")
+      end
+      after { dst_dataset.close }
+
+      context "when no options are provided" do
+        it "returns dst_dataset with changes applied" do
+          new_dataset = described_class.perform(dst_dataset: dst_dataset, src_datasets: [src_dataset])
+
+          expect(new_dataset).to eq(dst_dataset)
+          expect(new_dataset.driver.name).to eq("GeoJSON")
+          expect(new_dataset.layer(0).geometry_type).to eq(:wkbPolygon)
+        end
+      end
+
+      context "when options are provided" do
+        it "returns dst_dataset with changes applied with options" do
+          options = GDAL::Utils::VectorTranslate::Options.new(options: ["-nlt", "MULTIPOLYGON"])
+
+          new_dataset = described_class.perform(
+            dst_dataset: dst_dataset, src_datasets: [src_dataset], options: options
+          )
+
+          expect(new_dataset).to eq(dst_dataset)
+          expect(new_dataset.driver.name).to eq("GeoJSON")
+          expect(new_dataset.layer(0).geometry_type).to eq(:wkbMultiPolygon)
+        end
+      end
+
+      context "when operation fails with GDAL internal exception" do
+        it "raises exception" do
+          options = GDAL::Utils::VectorTranslate::Options.new(options: ["-where", "test123"])
+
+          expect do
+            described_class.perform(dst_dataset: dst_dataset, src_datasets: [src_dataset], options: options)
+          end.to raise_exception(
+            GDAL::Error, "SetAttributeFilter(test123) on layer 'states' failed."
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/gdal/utils/warp/options_spec.rb
+++ b/spec/unit/gdal/utils/warp/options_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "gdal"
+
+RSpec.describe GDAL::Utils::Warp::Options do
+  context "when no options are provided" do
+    it "returns a new instance of Options" do
+      subject { described_class.new }
+
+      expect(subject).to be_a(described_class)
+      expect(subject.c_pointer).to be_a(described_class::AutoPointer)
+      expect(subject.c_pointer).not_to be_null
+    end
+  end
+
+  context "when options are provided" do
+    subject { described_class.new(options: options) }
+
+    let(:options) { ["-multi", "-wo", "CUTLINE_ALL_TOUCHED=TRUE"] }
+
+    it "returns a new instance of Options with options" do
+      expect(subject).to be_a(described_class)
+      expect(subject.c_pointer).to be_a(described_class::AutoPointer)
+      expect(subject.c_pointer).not_to be_null
+    end
+  end
+
+  context "when incorrect options are provided" do
+    subject { described_class.new(options: options) }
+
+    let(:options) { ["-multi123"] }
+
+    it "raises exception" do
+      expect { subject }.to raise_exception(
+        GDAL::UnsupportedOperation, "Unknown option name '-multi123'"
+      )
+    end
+  end
+end

--- a/spec/unit/gdal/utils/warp_spec.rb
+++ b/spec/unit/gdal/utils/warp_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "gdal"
+
+RSpec.describe GDAL::Utils::Warp do
+  let(:src_dataset_path) do
+    path = "../../../../spec/support/images/osgeo/geotiff/GeogToWGS84GeoKey/GeogToWGS84GeoKey5.tif"
+    File.expand_path(path, __dir__)
+  end
+
+  let(:src_dataset) { GDAL::Dataset.open(src_dataset_path, "r") }
+  after { src_dataset.close }
+
+  describe ".perform" do
+    context "when dst_dataset_path used" do
+      let(:dst_dataset_path) { "/vsimem/test-#{SecureRandom.uuid}.tif" }
+
+      context "when no options are provided" do
+        it "returns new dataset" do
+          new_dataset = described_class.perform(dst_dataset_path: dst_dataset_path, src_datasets: [src_dataset])
+
+          expect(new_dataset).to be_a(GDAL::Dataset)
+          expect(GDAL::Utils::Info.perform(dataset: new_dataset)).not_to include("WGS 84 / Pseudo-Mercator")
+
+          new_dataset.close
+        end
+
+        it "returns new dataset in block" do
+          described_class.perform(dst_dataset_path: dst_dataset_path, src_datasets: [src_dataset]) do |new_dataset|
+            expect(new_dataset).to be_a(GDAL::Dataset)
+          end
+        end
+      end
+
+      context "when options are provided" do
+        it "returns new dataset with options applied" do
+          options = GDAL::Utils::Warp::Options.new(options: ["-t_srs", "EPSG:3857"])
+
+          new_dataset = described_class.perform(
+            dst_dataset_path: dst_dataset_path, src_datasets: [src_dataset], options: options
+          )
+
+          expect(new_dataset).to be_a(GDAL::Dataset)
+          expect(GDAL::Utils::Info.perform(dataset: new_dataset)).to include("WGS 84 / Pseudo-Mercator")
+
+          new_dataset.close
+        end
+      end
+
+      context "when operation fails with GDAL internal exception" do
+        it "raises exception" do
+          expect do
+            described_class.perform(dst_dataset_path: dst_dataset_path, src_datasets: [])
+          end.to raise_exception(
+            GDAL::Error, "No usable source images."
+          )
+        end
+      end
+
+      context "when operation fails without GDAL internal exception" do
+        it "raises exception" do
+          options = GDAL::Utils::Warp::Options.new(options: ["-of", "UnknownFormat123"])
+
+          expect do
+            described_class.perform(dst_dataset_path: dst_dataset_path, src_datasets: [src_dataset], options: options)
+          end.to raise_exception(
+            GDAL::Error, "GDALWarp failed."
+          )
+        end
+      end
+    end
+
+    context "when dst_dataset used" do
+      let(:dst_dataset) do
+        dataset = GDAL::Driver.by_name("GTiff").create_dataset("/vsimem/test-#{SecureRandom.uuid}.tif", 100, 100)
+
+        dataset.projection = OGR::SpatialReference.new.import_from_epsg(3857).to_wkt
+        dataset.geo_transform = GDAL::GeoTransform.new.tap do |gt|
+          gt.x_origin = 0
+          gt.y_origin = 0
+          gt.pixel_width = 10_000
+          gt.pixel_height = -10_000
+        end
+
+        dataset
+      end
+      after { dst_dataset.close }
+
+      context "when no options are provided" do
+        it "returns dst_dataset with changes applied" do
+          new_dataset = described_class.perform(dst_dataset: dst_dataset, src_datasets: [src_dataset])
+
+          expect(new_dataset).to eq(dst_dataset)
+          expect(GDAL::Utils::Info.perform(dataset: new_dataset)).to include("WGS 84 / Pseudo-Mercator")
+        end
+      end
+
+      context "when options are provided" do
+        it "returns dst_dataset with changes applied with options" do
+          options = GDAL::Utils::Warp::Options.new(options: ["-t_srs", "EPSG:3857"])
+
+          new_dataset = described_class.perform(
+            dst_dataset: dst_dataset, src_datasets: [src_dataset], options: options
+          )
+
+          expect(new_dataset).to eq(dst_dataset)
+          expect(GDAL::Utils::Info.perform(dataset: new_dataset)).to include("WGS 84 / Pseudo-Mercator")
+        end
+      end
+
+      context "when operation fails with GDAL internal exception" do
+        it "raises exception" do
+          options = GDAL::Utils::Warp::Options.new(options: ["-cutline", "/vsimem/unknown.shp"])
+
+          expect do
+            described_class.perform(dst_dataset: dst_dataset, src_datasets: [src_dataset], options: options)
+          end.to raise_exception(
+            GDAL::Error, "Cannot open /vsimem/unknown.shp."
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Very basic support for GDAL Utilities (https://gdal.org/api/gdal_utils.html).

`gdal_utils.h` provides C API for GDAL Utils (`gdalinfo`, `gdalwarp`, `gdal_translate`, etc).

Python bindings have it (`gdal.Warp`, `gdal.Translate`, etc). Those utils are quite useful and it would be great to have them in Ruby.

Notes:
- This PR implements only `GDALInfo` and `GDALTranslate` as a proof-of-concept. However, I plan to add other utils as well.
- ~~I am not very comfortable with FFI and GDAL C API pointers. Feel free to comment and advise if there is a better way to do things.~~
- ~~I intentionally do not expose `GDALInfoOptions` in rubyfied API. From my point of view, having to create and manage the lifecycle of the `GDALInfoOption` object would be a chore for the user. The user just needs to pass an array of strings.~~
- It would be cool to add valgrind to the specs to ensure that we do not leak memory (the RGeo gem uses valgrind in the specs for this purpose).
