### PR TITLE
fix: specs passing for GDAL 3

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Install GDAL
-        run: sudo apt-get install -y --no-install-recommends libgdal-dev librttopo-dev libproj-dev
+        run: sudo apt-get install -y --no-install-recommends libgdal-dev librttopo-dev
       - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/lib/ffi/ogr/srs_api.rb
+++ b/lib/ffi/ogr/srs_api.rb
@@ -38,6 +38,13 @@ module FFI
                        :ODT_LD_Min, 10_000,
                        :ODT_LD_Max, 32_767
 
+      # https://gdal.org/api/ogr_srs_api.html#_CPPv422OSRAxisMappingStrategy
+      OSRAxisMappingStrategy = enum(
+        :OAMS_TRADITIONAL_GIS_ORDER, 0,
+        :OAMS_AUTHORITY_COMPLIANT, 1,
+        :OAMS_CUSTOM, 2
+      )
+
       # -----------------------------------------------------------------------
       # Constants
       # -----------------------------------------------------------------------
@@ -125,6 +132,10 @@ module FFI
       # ~~~~~~~~~~~~~
       # SpatialReference
       # ~~~~~~~~~~~~~
+
+      # https://gdal.org/api/ogr_srs_api.html#_CPPv417OSRGetPROJVersionPiPiPi
+      attach_function :OSRGetPROJVersion, %i[pointer pointer pointer], :void
+
       attach_function :OSRNewSpatialReference, %i[string], :OGRSpatialReferenceH
       attach_function :OSRCloneGeogCS, %i[OGRSpatialReferenceH], :OGRSpatialReferenceH
       attach_function :OSRClone, %i[OGRSpatialReferenceH], :OGRSpatialReferenceH
@@ -214,6 +225,12 @@ module FFI
       attach_function :OSRGetAxis,
                       %i[OGRSpatialReferenceH string int pointer],
                       :string
+
+      # https://gdal.org/api/ogr_srs_api.html#_CPPv425OSRGetAxisMappingStrategy20OGRSpatialReferenceH
+      attach_function :OSRGetAxisMappingStrategy, %i[OGRSpatialReferenceH], OSRAxisMappingStrategy
+
+      # https://gdal.org/api/ogr_srs_api.html#_CPPv425OSRGetAxisMappingStrategy20OGRSpatialReferenceH
+      attach_function :OSRSetAxisMappingStrategy, [:OGRSpatialReferenceH, OSRAxisMappingStrategy], :void
 
       attach_function :OSRSetACEA,
                       %i[OGRSpatialReferenceH double double double double double double],

--- a/lib/ogr/spatial_reference.rb
+++ b/lib/ogr/spatial_reference.rb
@@ -14,6 +14,8 @@ module OGR
   #   1. "geographic", where positions are measured in long/lat.
   #   2. "projected", where positions are measure in meters or feet.
   class SpatialReference
+    Version = Struct.new(:major, :minor, :patch)
+
     include GDAL::Logger
     include SpatialReferenceMixins::CoordinateSystemGetterSetters
     include SpatialReferenceMixins::Exporters
@@ -123,6 +125,19 @@ module OGR
       return unless pointer && !pointer.null?
 
       FFI::OGR::SRSAPI.OSRRelease(pointer)
+    end
+
+    def self.proj_version
+      major_ptr = FFI::MemoryPointer.new(:int)
+      major_ptr.autorelease = false
+      minor_ptr = FFI::MemoryPointer.new(:int)
+      minor_ptr.autorelease = false
+      patch_ptr = FFI::MemoryPointer.new(:int)
+      patch_ptr.autorelease = false
+
+      FFI::OGR::SRSAPI.OSRGetPROJVersion(major_ptr, minor_ptr, patch_ptr)
+
+      Version.new(major_ptr.read_int, minor_ptr.read_int, patch_ptr.read_int)
     end
 
     # @return [FFI::Pointer] C pointer to the C Spatial Reference.
@@ -260,6 +275,16 @@ module OGR
     # @return [OGR::SpatialReference, FFI::Pointer] Pointer to an OGR::SpatialReference.
     def create_coordinate_transformation(destination_spatial_ref)
       OGR::CoordinateTransformation.new(@c_pointer, destination_spatial_ref)
+    end
+
+    # @return [nil] Sets the axis mapping strategy for this spatial reference.
+    def axis_mapping_strategy=(strategy)
+      FFI::OGR::SRSAPI.OSRSetAxisMappingStrategy(@c_pointer, strategy)
+    end
+
+    # @return [FFI::OGR::SRSAPI::AxisMappingStrategy] The axis mapping strategy.
+    def axis_mapping_strategy
+      FFI::OGR::SRSAPI.OSRGetAxisMappingStrategy(@c_pointer)
     end
   end
 end

--- a/spec/unit/ogr/coordinate_transformation_spec.rb
+++ b/spec/unit/ogr/coordinate_transformation_spec.rb
@@ -3,8 +3,20 @@
 require "ogr/coordinate_transformation"
 
 RSpec.describe OGR::CoordinateTransformation do
-  let(:source_srs) { OGR::SpatialReference.new.import_from_epsg(3857) }
-  let(:dest_srs) { OGR::SpatialReference.new.import_from_epsg(4326) }
+  let(:source_srs) do
+    OGR::SpatialReference.new.import_from_epsg(3857).tap do |srs|
+      # NOTE: GDAL 3 changed default axis order: https://github.com/OSGeo/gdal/issues/1546
+      # Set traditional axis order for GDAL3 to keep save behavior as for GDAL2.
+      srs.axis_mapping_strategy = :OAMS_TRADITIONAL_GIS_ORDER if GDAL.version_num >= "3000000"
+    end
+  end
+  let(:dest_srs) do
+    OGR::SpatialReference.new.import_from_epsg(4326).tap do |srs|
+      # NOTE: GDAL 3 changed default axis order: https://github.com/OSGeo/gdal/issues/1546
+      # Set traditional axis order for GDAL3 to keep save behavior as for GDAL2.
+      srs.axis_mapping_strategy = :OAMS_TRADITIONAL_GIS_ORDER if GDAL.version_num >= "3000000"
+    end
+  end
 
   # From https://epsg.io/3857
   let(:epsg4326_y_bounds) { [-85.06, 85.06] }

--- a/spec/unit/ogr/geometries/geometry_collection_spec.rb
+++ b/spec/unit/ogr/geometries/geometry_collection_spec.rb
@@ -87,7 +87,16 @@ RSpec.describe OGR::GeometryCollection do
         end
 
         it "returns WKT with the merged strings" do
-          expect(subject.to_wkt).to eq "POLYGON ((0 0,0 1,0 2,1 1,1 2,1 3))"
+          # NOTE: The WKT result is different between GDAL 2 and GDAL 3.
+          # Just documenting the difference here.
+          expected_wkt =
+            if GDAL.version_num < "3000000"
+              "POLYGON ((0 0,0 1,0 2,1 1,1 2,1 3))"
+            else
+              "POLYGON ((0 0,0 1,0 2,1 2,1 3))"
+            end
+
+          expect(subject.to_wkt).to eq(expected_wkt)
         end
       end
 
@@ -146,8 +155,16 @@ RSpec.describe OGR::GeometryCollection do
         end
 
         it "returns WKT with the merged strings" do
-          expect(subject.to_wkt)
-            .to eq "POLYGON ((0 0 0,0 1 0,0 2 0,1 1 0,1 2 0,1 3 0,0 0 0))"
+          # NOTE: The WKT result is different between GDAL 2 and GDAL 3.
+          # Just documenting the difference here.
+          expected_wkt =
+            if GDAL.version_num < "3000000"
+              "POLYGON ((0 0 0,0 1 0,0 2 0,1 1 0,1 2 0,1 3 0,0 0 0))"
+            else
+              "POLYGON ((0 0 0,0 1 0,0 2 0,1 2 0,0 0 0))"
+            end
+
+          expect(subject.to_wkt).to eq(expected_wkt)
         end
       end
 

--- a/spec/unit/ogr/spatial_reference_mixins/importers_spec.rb
+++ b/spec/unit/ogr/spatial_reference_mixins/importers_spec.rb
@@ -6,32 +6,61 @@ RSpec.describe OGR::SpatialReference do
   describe "#import_from_epsg" do
     context "valid code" do
       it "updates self's info" do
-        expect do
-          subject.import_from_epsg(4326)
-        end.to change { subject.to_wkt.size }.from(0)
+        if GDAL.version_num < "3000000"
+          # NOTE: GDAL 2 returns an empty string instead of raise exception.
+          expect(subject.to_wkt).to eq("")
+        else
+          expect { subject.to_wkt }.to raise_exception(OGR::Failure, "Unable to export to WKT")
+        end
+
+        subject.import_from_epsga(4326)
+
+        expect(subject.to_wkt).to start_with("GEOGCS[\"WGS 84\",DATUM[\"")
       end
 
-      it "does not treat as lat/lon" do
+      it "treats 4326 as lat/lon" do
         subject.import_from_epsg(4326)
-        expect(subject.epsg_treats_as_lat_long?).to eq false
+
+        if GDAL.version_num < "3000000"
+          # NOTE: Looks like it should be `true`, as in GDAL 3.
+          # By some reason GDAL 2 returns `false`.
+          expect(subject.epsg_treats_as_lat_long?).to eq false
+        else
+          expect(subject.epsg_treats_as_lat_long?).to eq true
+        end
       end
     end
 
     context "invalid code" do
-      it "raises a GDAL::UnsupportedOperation" do
-        expect { subject.import_from_epsg 1_231_234 }.to raise_exception GDAL::UnsupportedOperation
+      it "raises an exception" do
+        if GDAL.version_num < "3000000"
+          expect { subject.import_from_epsg(1_231_234) }.to raise_exception(
+            GDAL::UnsupportedOperation
+          )
+        else
+          expect { subject.import_from_epsg(1_231_234) }.to raise_exception(
+            GDAL::Error, "PROJ: proj_create_from_database: crs not found"
+          )
+        end
       end
     end
   end
 
   describe "#import_from_epsga" do
     it "updates self's info" do
-      expect do
-        subject.import_from_epsga(4326)
-      end.to change { subject.to_wkt.size }.from(0)
+      if GDAL.version_num < "3000000"
+        # NOTE: GDAL 2 returns an empty string instead of raise exception.
+        expect(subject.to_wkt).to eq("")
+      else
+        expect { subject.to_wkt }.to raise_exception(OGR::Failure, "Unable to export to WKT")
+      end
+
+      subject.import_from_epsga(4326)
+
+      expect(subject.to_wkt).to start_with("GEOGCS[\"WGS 84\",DATUM[\"")
     end
 
-    it "treats as lat/lon" do
+    it "treats 4326 as lat/lon" do
       subject.import_from_epsga(4326)
       expect(subject.epsg_treats_as_lat_long?).to eq true
     end

--- a/spec/unit/ogr/spatial_reference_spec.rb
+++ b/spec/unit/ogr/spatial_reference_spec.rb
@@ -7,7 +7,21 @@ RSpec.describe OGR::SpatialReference do
     described_class.new.import_from_epsg(3819)
   end
 
-  describe ".projection_methods" do
+  describe ".proj_version" do
+    it "returns a Version with proper attributes" do
+      skip "Only available starting GDAL 3.0.1" if GDAL.version_num < "3000100"
+
+      version = described_class.proj_version
+
+      expect(version.major).to be_an_instance_of(Integer)
+      expect(version.minor).to be_an_instance_of(Integer)
+      expect(version.patch).to be_an_instance_of(Integer)
+    end
+  end
+
+  # NOTE: `.projection_methods` was removed without a replacement in GDAL 3.0.
+  projection_methods_skip_reason = GDAL.version_num >= "3000000" ? "GDAL 3 removed this method" : false
+  describe ".projection_methods", skip: projection_methods_skip_reason do
     context "strip underscores" do
       subject { described_class.projection_methods(strip_underscores: true) }
 
@@ -32,6 +46,23 @@ RSpec.describe OGR::SpatialReference do
       it "has Strings with underscores" do
         expect(subject).to(satisfy { |v| !v.include?(" ") })
       end
+    end
+  end
+
+  describe "#axis_mapping_strategy" do
+    it "returns default OAMS_AUTHORITY_COMPLIANT strategy" do
+      skip "Only available in GDAL 3" if GDAL.version_num < "3000000"
+
+      expect(subject.axis_mapping_strategy).to eq(:OAMS_AUTHORITY_COMPLIANT)
+    end
+  end
+
+  describe "#axis_mapping_strategy=" do
+    it "sets the axis_mapping_strategy" do
+      skip "Only available in GDAL 3" if GDAL.version_num < "3000000"
+
+      subject.axis_mapping_strategy = :OAMS_TRADITIONAL_GIS_ORDER
+      expect(subject.axis_mapping_strategy).to eq(:OAMS_TRADITIONAL_GIS_ORDER)
     end
   end
 


### PR DESCRIPTION
- added `OSRGetAxisMappingStrategy`
- added `OSRSetAxisMappingStrategy`
- added `OSRGetPROJVersion`
- added `#axis_mapping_strategy` setter/getter to `OGR::SpatialReference`
- added `.proj_version` getter to `OGR::SpatialReference`
- made specs passing for GDAL 3