### PR TITLE
feat: better raster band offset/scaling handling

### DIFF
--- a/lib/gdal/raster_band.rb
+++ b/lib/gdal/raster_band.rb
@@ -347,14 +347,16 @@ module GDAL
     # returned.
     #
     # @return Float
-    # @raise GDAL::Error if the underlying call fails.
     def scale
+      FFI::GDAL::GDAL.GDALGetRasterScale(@c_pointer, nil)
+    end
+
+    # Check if the scale is set.
+    # @return [Boolean]
+    def scale?
       success = FFI::MemoryPointer.new(:bool)
-      result = FFI::GDAL::GDAL.GDALGetRasterScale(@c_pointer, success)
-
-      raise GDAL::Error, "GDALGetRasterScale failed" unless success.read_bytes(1).to_bool
-
-      result
+      FFI::GDAL::GDAL.GDALGetRasterScale(@c_pointer, success)
+      success.read_bytes(1).to_bool
     end
 
     # @param new_scale [Float]
@@ -376,14 +378,16 @@ module GDAL
     # returned.
     #
     # @return Float
-    # @raise GDAL::Error if the underlying call fails.
     def offset
+      FFI::GDAL::GDAL.GDALGetRasterOffset(@c_pointer, nil)
+    end
+
+    # Check if the offset is set.
+    # @return [Boolean]
+    def offset?
       success = FFI::MemoryPointer.new(:bool)
-      result = FFI::GDAL::GDAL.GDALGetRasterOffset(@c_pointer, success)
-
-      raise GDAL::Error, "GDALGetRasterOffset failed" unless success.read_bytes(1).to_bool
-
-      result
+      FFI::GDAL::GDAL.GDALGetRasterOffset(@c_pointer, success)
+      success.read_bytes(1).to_bool
     end
 
     # Sets the scaling offset. Very few formats support this method.

--- a/spec/integration/gdal/raster_band_info_spec.rb
+++ b/spec/integration/gdal/raster_band_info_spec.rb
@@ -178,26 +178,88 @@ RSpec.describe "Raster Band Info", type: :integration do
   end
 
   describe "#scale" do
-    it "returns a Float" do
-      expect(subject.scale).to be_a Float
+    context "when scale is not set" do
+      it "returns 1.0" do
+        expect(subject.scale).to eq(1.0)
+      end
+    end
+
+    context "when scale is set" do
+      it "returns scale" do
+        subject.scale = 12.345
+        expect(subject.scale).to eq(12.345)
+      end
+    end
+  end
+
+  describe "#scale?" do
+    context "when scale is not set" do
+      it "returns false" do
+        if GDAL.version_num >= "3040000"
+          # NOTE: This is an expeced behavior in GDAL 3.4+.
+          expect(subject.scale?).to be(false)
+        else
+          # NOTE: This is kinda unexpected behavior in older versions of GDAL.
+          # Just documenting it here.
+          expect(subject.scale?).to be(true)
+        end
+      end
+    end
+
+    context "when scale is set" do
+      it "returns true" do
+        subject.scale = 12.345
+        expect(subject.scale?).to be(true)
+      end
     end
   end
 
   describe "#scale=" do
-    it "does nothing (because the file formats dont support it)" do
+    it "set scale" do
       subject.scale = 0.1
       expect(subject.scale).to eq 0.1
     end
   end
 
   describe "#offset" do
-    it "returns a Float" do
-      expect(subject.offset).to be_a Float
+    context "when offset is not set" do
+      it "returns 0.0" do
+        expect(subject.offset).to eq(0.0)
+      end
+    end
+
+    context "when offset is set" do
+      it "returns offset" do
+        subject.offset = 12.345
+        expect(subject.offset).to eq(12.345)
+      end
+    end
+  end
+
+  describe "#offset?" do
+    context "when offset is not set" do
+      it "returns false" do
+        if GDAL.version_num >= "3040000"
+          # NOTE: This is an expeced behavior in GDAL 3.4+.
+          expect(subject.offset?).to be(false)
+        else
+          # NOTE: This is kinda unexpected behavior in older versions of GDAL.
+          # Just documenting it here.
+          expect(subject.offset?).to be(true)
+        end
+      end
+    end
+
+    context "when offset is set" do
+      it "returns true" do
+        subject.offset = 12.345
+        expect(subject.offset?).to be(true)
+      end
     end
   end
 
   describe "#offset=" do
-    it "does nothing (because the file formats dont support it)" do
+    it "set offset" do
       subject.offset = 0.1
       expect(subject.offset).to eq 0.1
     end


### PR DESCRIPTION
Changes to `GDAL::RasterBand`:
- added `#scale?`;
- added `#offset?`;
- aligned `#scale` with GDAL C API (e.g. return 1.0 if the scale is not set or not implemented by a driver instead of an exception);
- aligned `#offset` with GDAL C API (e.g. return 0.0 if the offset is not set or not implemented by a driver instead of an exception).

This is a part of the changes for GDAL 3.4+ compatibility (ubuntu-22.04 specs).