### PR TITLE
build: add .vscode folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 .byebug_history
 .config
 .idea/
+.vscode/
 .rake_tasks
 .tags
 .yardoc


### PR DESCRIPTION
The `.vscode` folder is used by the VSCode editor to keep local settings (the same as `.idea` for the IntelliJ IDEA family of IDEs).