### PR TITLE
feat: add support for GDT_Int8, GDT_UInt64 and GDT_Int64

### DIFF
--- a/lib/ext/numeric_as_data_type.rb
+++ b/lib/ext/numeric_as_data_type.rb
@@ -4,7 +4,7 @@ module NumericAsDataType
   # @param data_type [FFI::GDAL::GDAL::DataType]
   def to_data_type(data_type)
     case data_type
-    when :GDT_Byte, :GDT_UInt16, :GDT_Int16, :GDT_UInt32, :GDT_Int32
+    when :GDT_Byte, :GDT_Int8, :GDT_UInt16, :GDT_Int16, :GDT_UInt32, :GDT_Int32, :GDT_UInt64, :GDT_Int64
       to_i
     when :GDT_Float32, :GDT_Float64
       to_f

--- a/lib/ffi/gdal/gdal.rb
+++ b/lib/ffi/gdal/gdal.rb
@@ -6,6 +6,7 @@ require_relative "color_entry"
 
 module FFI
   module GDAL
+    # rubocop:disable Metrics/ModuleLength
     module GDAL
       extend ::FFI::Library
       ffi_lib [::FFI::CURRENT_PROCESS, ::FFI::GDAL.gdal_library_path]
@@ -13,19 +14,24 @@ module FFI
       # ----------------------------------------------------------------
       # Enums
       # ----------------------------------------------------------------
-      DataType = enum :GDT_Unknown, 0,
+      # https://gdal.org/doxygen/gdal_8h_source.html
+      # NOTE: GDT_TypeCount is maximum type # + 1.
+      DataType = enum :GDT_Unknown,     0,
                       :GDT_Byte,        1,
+                      :GDT_Int8,        14,
                       :GDT_UInt16,      2,
                       :GDT_Int16,       3,
                       :GDT_UInt32,      4,
                       :GDT_Int32,       5,
+                      :GDT_UInt64,      12,
+                      :GDT_Int64,       13,
                       :GDT_Float32,     6,
                       :GDT_Float64,     7,
                       :GDT_CInt16,      8,
                       :GDT_CInt32,      9,
                       :GDT_CFloat32,    10,
                       :GDT_CFloat64,    11,
-                      :GDT_TypeCount,   12
+                      :GDT_TypeCount,   15
 
       AsyncStatusType = enum :GARIO_PENDING, 0,
                              :GARIO_UPDATE,     1,
@@ -679,5 +685,6 @@ module FFI
                       %i[pointer int int pointer int int int int],
                       :void
     end
+    # rubocop:enable Metrics/ModuleLength
   end
 end

--- a/lib/gdal/internal_helpers.rb
+++ b/lib/gdal/internal_helpers.rb
@@ -141,10 +141,13 @@ module GDAL
       def _gdal_data_type_to_ffi(data_type)
         case data_type
         when :GDT_Byte                    then :uchar
+        when :GDT_Int8                    then :int8
         when :GDT_UInt16                  then :uint16
         when :GDT_Int16, :GDT_CInt16      then :int16
         when :GDT_UInt32                  then :uint32
         when :GDT_Int32, :GDT_CInt32      then :int32
+        when :GDT_UInt64                  then :uint64
+        when :GDT_Int64                   then :int64
         when :GDT_Float32, :GDT_CFloat32  then :float
         when :GDT_Float64, :GDT_CFloat64  then :double
         else

--- a/spec/unit/ext/numeric_as_data_type_spec.rb
+++ b/spec/unit/ext/numeric_as_data_type_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Numeric do
   let(:integer_data_types) do
-    %i[GDT_Byte GDT_UInt16 GDT_Int16 GDT_UInt32 GDT_Int32]
+    %i[GDT_Byte GDT_Int8 GDT_UInt16 GDT_Int16 GDT_UInt32 GDT_Int32 GDT_UInt64 GDT_Int64]
   end
 
   let(:float_data_types) do

--- a/spec/unit/gdal/extensions/raster_band/io_extensions_spec.rb
+++ b/spec/unit/gdal/extensions/raster_band/io_extensions_spec.rb
@@ -6,10 +6,13 @@ require "gdal/extensions/raster_band/io_extensions"
 RSpec.describe "GDAL::RasterBand::IOExtensions" do
   let(:driver) { GDAL::Driver.by_name("MEM") }
   let(:dataset_byte) { driver.create_dataset("test", 15, 25, data_type: :GDT_Byte) }
-  let(:dataset_int16) { driver.create_dataset("test", 15, 25, data_type: :GDT_Int16) }
+  let(:dataset_int8) { driver.create_dataset("test", 15, 25, data_type: :GDT_Int8) }
   let(:dataset_uint16) { driver.create_dataset("test", 15, 25, data_type: :GDT_UInt16) }
-  let(:dataset_int32) { driver.create_dataset("test", 15, 25, data_type: :GDT_Int32) }
+  let(:dataset_int16) { driver.create_dataset("test", 15, 25, data_type: :GDT_Int16) }
   let(:dataset_uint32) { driver.create_dataset("test", 15, 25, data_type: :GDT_UInt32) }
+  let(:dataset_int32) { driver.create_dataset("test", 15, 25, data_type: :GDT_Int32) }
+  let(:dataset_uint64) { driver.create_dataset("test", 15, 25, data_type: :GDT_UInt64) }
+  let(:dataset_int64) { driver.create_dataset("test", 15, 25, data_type: :GDT_Int64) }
   let(:dataset_float32) { driver.create_dataset("test", 15, 25, data_type: :GDT_Float32) }
   let(:dataset_float64) { driver.create_dataset("test", 15, 25, data_type: :GDT_Float64) }
 
@@ -44,12 +47,12 @@ RSpec.describe "GDAL::RasterBand::IOExtensions" do
       end
     end
 
-    context "valid values, GDT_Int16" do
-      subject { dataset_int16.raster_band(1) }
-
+    context "valid values, GDT_Int8" do
       it "sets and gets the value successfully" do
-        subject.set_pixel_value(0, 0, -12_345)
-        expect(subject.pixel_value(0, 0)).to eq(-12_345)
+        skip "This spec only for GDAL 3.7+" if GDAL.version_num < "3070000"
+
+        subject.set_pixel_value(0, 0, -128)
+        expect(subject.pixel_value(0, 0)).to eq(-128)
       end
     end
 
@@ -62,12 +65,12 @@ RSpec.describe "GDAL::RasterBand::IOExtensions" do
       end
     end
 
-    context "valid values, GDT_Int32" do
-      subject { dataset_int32.raster_band(1) }
+    context "valid values, GDT_Int16" do
+      subject { dataset_int16.raster_band(1) }
 
       it "sets and gets the value successfully" do
-        subject.set_pixel_value(0, 0, -123_456_789)
-        expect(subject.pixel_value(0, 0)).to eq(-123_456_789)
+        subject.set_pixel_value(0, 0, -12_345)
+        expect(subject.pixel_value(0, 0)).to eq(-12_345)
       end
     end
 
@@ -77,6 +80,37 @@ RSpec.describe "GDAL::RasterBand::IOExtensions" do
       it "sets and gets the value successfully" do
         subject.set_pixel_value(0, 0, 4_123_456_789)
         expect(subject.pixel_value(0, 0)).to eq(4_123_456_789)
+      end
+    end
+
+    context "valid values, GDT_Int32" do
+      subject { dataset_int32.raster_band(1) }
+
+      it "sets and gets the value successfully" do
+        subject.set_pixel_value(0, 0, -123_456_789)
+        expect(subject.pixel_value(0, 0)).to eq(-123_456_789)
+      end
+    end
+
+    context "valid values, GDT_UInt64" do
+      subject { dataset_uint64.raster_band(1) }
+
+      it "sets and gets the value successfully" do
+        skip "This spec only for GDAL 3.5+" if GDAL.version_num < "3050000"
+
+        subject.set_pixel_value(0, 0, 18_446_744_073_709_551_615)
+        expect(subject.pixel_value(0, 0)).to eq(18_446_744_073_709_551_615)
+      end
+    end
+
+    context "valid values, GDT_Int64" do
+      subject { dataset_int64.raster_band(1) }
+
+      it "sets and gets the value successfully" do
+        skip "This spec only for GDAL 3.5+" if GDAL.version_num < "3050000"
+
+        subject.set_pixel_value(0, 0, -9_223_372_036_854_775_808)
+        expect(subject.pixel_value(0, 0)).to eq(-9_223_372_036_854_775_808)
       end
     end
 

--- a/spec/unit/gdal/internal_helpers_spec.rb
+++ b/spec/unit/gdal/internal_helpers_spec.rb
@@ -65,6 +65,11 @@ RSpec.describe GDAL::InternalHelpers do
       it { is_expected.to eq :uchar }
     end
 
+    context "data type is :GDT_Int8" do
+      subject { tester._gdal_data_type_to_ffi(:GDT_Int8) }
+      it { is_expected.to eq :int8 }
+    end
+
     context "data type is :GDT_UInt16" do
       subject { tester._gdal_data_type_to_ffi(:GDT_UInt16) }
       it { is_expected.to eq :uint16 }
@@ -83,6 +88,16 @@ RSpec.describe GDAL::InternalHelpers do
     context "data type is :GDT_Int32" do
       subject { tester._gdal_data_type_to_ffi(:GDT_Int32) }
       it { is_expected.to eq :int32 }
+    end
+
+    context "data type is :GDT_UInt64" do
+      subject { tester._gdal_data_type_to_ffi(:GDT_UInt64) }
+      it { is_expected.to eq :uint64 }
+    end
+
+    context "data type is :GDT_Int64" do
+      subject { tester._gdal_data_type_to_ffi(:GDT_Int64) }
+      it { is_expected.to eq :int64 }
     end
 
     context "data type is :GDT_Float32" do


### PR DESCRIPTION
- `GDT_Int8` is availalbe in GDAL 3.7+
- `GDT_UInt64` and `GDT_Int64` are available in GDAL 3.5+