### PR TITLE
feat: add support for new GDAL CPLE error codes

### DIFF
--- a/lib/gdal/cpl_error_handler.rb
+++ b/lib/gdal/cpl_error_handler.rb
@@ -9,19 +9,27 @@ module GDAL
   class CPLErrorHandler
     include GDAL::Logger
 
+    # NOTE: Error codes are defined in https://gdal.org/doxygen/cpl__error_8h_source.html
     CPLE_MAP = [
-      { cple: :CPLE_None,           exception: nil }.freeze,
-      { cple: :CPLE_AppDefined,     exception: GDAL::Error }.freeze,
-      { cple: :CPLE_OutOfMemory,    exception: ::NoMemoryError }.freeze,
-      { cple: :CPLE_FileIO,         exception: ::IOError }.freeze,
-      { cple: :CPLE_OpenFailed,     exception: GDAL::OpenFailure }.freeze,
-      { cple: :CPLE_IllegalArg,     exception: ::ArgumentError }.freeze,
-      { cple: :CPLE_NotSupported,   exception: GDAL::UnsupportedOperation }.freeze,
-      { cple: :CPLE_AssertionFailed, exception: ::RuntimeError }.freeze,
-      { cple: :CPLE_NoWriteAccess,  exception: GDAL::NoWriteAccess }.freeze,
-      { cple: :CPLE_UserInterrupt,  exception: ::Interrupt }.freeze,
-      { cple: :CPLE_ObjectNull,     exception: GDAL::NullObject }.freeze
+      { cple: :CPLE_None,                     exception: nil }.freeze,
+      { cple: :CPLE_AppDefined,               exception: GDAL::Error }.freeze,
+      { cple: :CPLE_OutOfMemory,              exception: ::NoMemoryError }.freeze,
+      { cple: :CPLE_FileIO,                   exception: ::IOError }.freeze,
+      { cple: :CPLE_OpenFailed,               exception: GDAL::OpenFailure }.freeze,
+      { cple: :CPLE_IllegalArg,               exception: ::ArgumentError }.freeze,
+      { cple: :CPLE_NotSupported,             exception: GDAL::UnsupportedOperation }.freeze,
+      { cple: :CPLE_AssertionFailed,          exception: ::RuntimeError }.freeze,
+      { cple: :CPLE_NoWriteAccess,            exception: GDAL::NoWriteAccess }.freeze,
+      { cple: :CPLE_UserInterrupt,            exception: ::Interrupt }.freeze,
+      { cple: :CPLE_ObjectNull,               exception: GDAL::NullObject }.freeze,
+      { cple: :CPLE_HttpResponse,             exception: GDAL::HttpResponse }.freeze,
+      { cple: :CPLE_AWSBucketNotFound,        exception: GDAL::AWSBucketNotFound }.freeze,
+      { cple: :CPLE_AWSObjectNotFound,        exception: GDAL::AWSObjectNotFound }.freeze,
+      { cple: :CPLE_AWSAccessDenied,          exception: GDAL::AWSAccessDenied }.freeze,
+      { cple: :CPLE_AWSInvalidCredentials,    exception: GDAL::AWSInvalidCredentials }.freeze,
+      { cple: :CPLE_AWSSignatureDoesNotMatch, exception: GDAL::AWSSignatureDoesNotMatch }.freeze
     ].freeze
+    FALLBACK_CPLE_EXCEPTION = { exception: GDAL::Error }.freeze
 
     FAIL_PROC = lambda do |exception, message|
       ex = exception ? exception.new(message) : GDAL::Error.new(message)
@@ -127,7 +135,10 @@ module GDAL
 
     # @return Whatever the Proc evaluates.
     def result(error_class, error_number, message)
-      error_class_map(error_class).call(CPLE_MAP[error_number][:exception], message)
+      error_class_map(error_class).call(
+        CPLE_MAP.fetch(error_number, FALLBACK_CPLE_EXCEPTION).fetch(:exception),
+        message
+      )
     end
 
     def error_class_map(error_class)

--- a/lib/gdal/exceptions.rb
+++ b/lib/gdal/exceptions.rb
@@ -1,20 +1,48 @@
 # frozen_string_literal: true
 
 module GDAL
-  class BufferTooSmall < StandardError
-  end
-
-  class CreateFail < StandardError
-  end
-
   class Error < ::RuntimeError
   end
 
-  class OpenFailure < StandardError
+  # CPLE_OpenFailed
+  class OpenFailure < ::StandardError
     def initialize(file, msg = nil)
       message = msg || "Unable to open file '#{file}'. Perhaps an unsupported file format?"
       super(message)
     end
+  end
+
+  # CPLE_NotSupported
+  class UnsupportedOperation < ::StandardError; end
+
+  # CPLE_NoWriteAccess
+  class NoWriteAccess < ::RuntimeError; end
+
+  # CPLE_ObjectNull
+  class NullObject < ::TypeError; end
+
+  # CPLE_HttpResponse
+  class HttpResponse < ::RuntimeError; end
+
+  # CPLE_AWSBucketNotFound
+  class AWSBucketNotFound < ::RuntimeError; end
+
+  # CPLE_AWSObjectNotFound
+  class AWSObjectNotFound < ::RuntimeError; end
+
+  # CPLE_AWSAccessDenied
+  class AWSAccessDenied < ::RuntimeError; end
+
+  # CPLE_AWSInvalidCredentials
+  class AWSInvalidCredentials < ::RuntimeError; end
+
+  # CPLE_AWSSignatureDoesNotMatch
+  class AWSSignatureDoesNotMatch < ::RuntimeError; end
+
+  class BufferTooSmall < StandardError
+  end
+
+  class CreateFail < StandardError
   end
 
   class InvalidAccessFlag < RuntimeError
@@ -51,12 +79,6 @@ module GDAL
   class NoValuesToGrid < RuntimeError
   end
 
-  class NoWriteAccess < RuntimeError
-  end
-
-  class NullObject < TypeError
-  end
-
   class RequiredBandNotFound < StandardError
   end
 
@@ -68,8 +90,5 @@ module GDAL
   end
 
   class UnknownRasterAttributeTableType < StandardError
-  end
-
-  class UnsupportedOperation < StandardError
   end
 end


### PR DESCRIPTION
In newer GDAL versions, new CPLE error codes were added.

From https://gdal.org/doxygen/cpl__error_8h_source.html:

```C
typedef enum
{
    CPLE_None,
    CPLE_AppDefined,
    CPLE_OutOfMemory,
    CPLE_FileIO,
    CPLE_OpenFailed,
    CPLE_IllegalArg,
    CPLE_NotSupported,
    CPLE_AssertionFailed,
    CPLE_NoWriteAccess,
    CPLE_UserInterrupt,
    CPLE_ObjectNull,
    CPLE_HttpResponse,
    CPLE_AWSBucketNotFound,
    CPLE_AWSObjectNotFound,
    CPLE_AWSAccessDenied,
    CPLE_AWSInvalidCredentials,
    CPLE_AWSSignatureDoesNotMatch,
} CPLErrorNum;
```

- Added support for new GDAL CPLE error codes.
- Added a generic `GDAL::Error` fallback if new codes will be added to GDAL to avoid `undefined method [] for nil` exception.