### PR TITLE
fix: Add /opt/homebrew/include to header search paths

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,7 +19,6 @@ jobs:
         run: bundle exec rubocop --format github --parallel
 
   test:
-    needs: [static_analysis]
     strategy:
       fail-fast: false
       matrix:
@@ -29,11 +28,13 @@ jobs:
         # - ubuntu-24.04 has GDAL 3.8.4, PROJ 9.4.0, GEOS 3.12.1
         os: ["ubuntu-20.04", "ubuntu-22.04", "ubuntu-24.04"]
         ruby-version: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3"]
-    name: "Ruby ${{ matrix.ruby-version }} on ${{ matrix.os }}"
+    name: "Test on Ruby ${{ matrix.ruby-version }} on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install GDAL
-        run: sudo apt-get install -y --no-install-recommends libgdal-dev librttopo-dev
+        run:
+          sudo apt-get install -y --no-install-recommends libgdal-dev
+          librttopo-dev
       - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -41,4 +42,6 @@ jobs:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
       - name: Run specs
-        run: bundle exec rspec spec --format RSpec::Github::Formatter --format progress
+        run:
+          bundle exec rspec spec --format RSpec::Github::Formatter --format
+          progress

--- a/.github/workflows/specs-in-docker.yml
+++ b/.github/workflows/specs-in-docker.yml
@@ -5,8 +5,8 @@ on:
   push:
 
 jobs:
-  test:
-    name: Test
+  docker_test:
+    name: Docker Test (GDAL2)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -21,10 +21,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
       - name: Log in to registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+        run:
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $
+          --password-stdin
       - name: Build gdal2 image
         run: |
           docker compose version
           docker compose build gdal2
       - name: Run specs
-        run: docker compose run --rm gdal2 bundle exec rspec spec --format RSpec::Github::Formatter --format progress
+        run:
+          docker compose run --rm gdal2 bundle exec rspec spec --format
+          RSpec::Github::Formatter --format progress
+

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Fixed
+
+- gh-74: Add `/opt/homebrew/include` to header file search paths (fix for
+  macOS).
+
 ## [1.0.4] - 2023-02-06
 
 ### Fixed

--- a/lib/ffi/gdal.rb
+++ b/lib/ffi/gdal.rb
@@ -41,7 +41,7 @@ module FFI
         ogr_core.h ogr_srs_api.h
       ]
 
-      header_search_paths = %w[/usr/local/include /usr/include /usr/include/gdal]
+      header_search_paths = %w[/usr/local/include /usr/include /usr/include/gdal /opt/homebrew/include/]
 
       header_files.map do |file|
         dir = header_search_paths.find do |d|


### PR DESCRIPTION
This header PATH searching should be done better, but does alleavite the error and make sense. This is probably broken for all Apple-silicon machines that use Homebrew (well, at least when Homebrew setups install outside of /usr/).

Note: while tests seem to be passing in the GH actions, I still get 13 failures locally.

gh-74

---

- [x] Update Changelog