### PR TITLE
fix: map OGRERR_NON_EXISTING_FEATURE to a Ruby exception

### DIFF
--- a/lib/ffi/ogr/core.rb
+++ b/lib/ffi/ogr/core.rb
@@ -25,7 +25,8 @@ module FFI
                  :OGRERR_CORRUPT_DATA,
                  :OGRERR_FAILURE,
                  :OGRERR_UNSUPPORTED_SRS,
-                 :OGRERR_INVALID_HANDLE
+                 :OGRERR_INVALID_HANDLE,
+                 :OGRERR_NON_EXISTING_FEATURE
 
       WKBGeometryType = enum FFI::Type::UINT,
                              :wkbUnknown,                0,

--- a/lib/ogr/error_handling.rb
+++ b/lib/ogr/error_handling.rb
@@ -21,7 +21,8 @@ module OGR
       OGRERR_CORRUPT_DATA: OGR::CorruptData,
       OGRERR_FAILURE: OGR::Failure,
       OGRERR_UNSUPPORTED_SRS: OGR::UnsupportedSRS,
-      OGRERR_INVALID_HANDLE: OGR::InvalidHandle
+      OGRERR_INVALID_HANDLE: OGR::InvalidHandle,
+      OGRERR_NON_EXISTING_FEATURE: OGR::NonExistingFeature
     }.freeze
 
     # Yields, then expects the result to be a Symbol from FFI::OGR::Core::Err.
@@ -30,7 +31,7 @@ module OGR
     def self.handle_ogr_err(msg)
       ogr_err_symbol = yield
 
-      klass = ERROR_CLASS_MAP.fetch(ogr_err_symbol) { raise "Unknown OGRERR type: #{self}" }
+      klass = ERROR_CLASS_MAP.fetch(ogr_err_symbol) { raise "Unknown OGRERR type: #{ogr_err_symbol}" }
 
       raise_exception(klass, msg) if klass
     end

--- a/lib/ogr/exceptions.rb
+++ b/lib/ogr/exceptions.rb
@@ -58,6 +58,9 @@ module OGR
   class InvalidSpatialReference < StandardError
   end
 
+  class NonExistingFeature < Failure
+  end
+
   class NotEnoughData < RuntimeError
   end
 

--- a/spec/unit/ogr/error_handling_spec.rb
+++ b/spec/unit/ogr/error_handling_spec.rb
@@ -66,5 +66,19 @@ RSpec.describe OGR::ErrorHandling do
           .to raise_exception OGR::InvalidHandle
       end
     end
+
+    context ":OGRERR_NON_EXISTING_FEATURE" do
+      it "raises an OGR::NonExistingFeature exception" do
+        expect { described_class.handle_ogr_err("") { :OGRERR_NON_EXISTING_FEATURE } }
+          .to raise_exception OGR::NonExistingFeature
+      end
+    end
+
+    context "unknown OGRERR type" do
+      it "raises a RuntimeError naming the unknown type" do
+        expect { described_class.handle_ogr_err("") { :OGRERR_BOGUS } }
+          .to raise_exception RuntimeError, "Unknown OGRERR type: OGRERR_BOGUS"
+      end
+    end
   end
 end


### PR DESCRIPTION
GDAL 3.12 returns `OGRERR_NON_EXISTING_FEATURE` (ogr_core.h value 9, present since GDAL 2.0) from `OGR_L_SetNextByIndex` when the index is out of range. The FFI enum did not define it, so the error handler received a raw Integer and crashed with 'Unknown OGRERR type' — a message that also interpolated the module instead of the offending value.

Add the enum member, map it to a new `OGR::NonExistingFeature` exception (a subclass of `OGR::Failure`, which callers already rescue), and make the unknown-type message name the actual value.

Related to GDAL 3.12 compatibility.