### PR TITLE
ci: run apt-get update before installing GDAL

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -32,9 +32,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install GDAL
-        run:
-          sudo apt-get install -y --no-install-recommends libgdal-dev
-          librttopo-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libgdal-dev librttopo-dev
       - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -43,5 +43,4 @@ jobs:
           bundler-cache: true
       - name: Run specs
         run:
-          bundle exec rspec spec --format RSpec::Github::Formatter --format
-          progress
+          bundle exec rspec spec --format RSpec::Github::Formatter --format progress


### PR DESCRIPTION
GitHub-hosted runner images ship with baked-in apt package lists that go stale. Refresh the package lists first.