### PR TITLE
fix: send requested GMF flags to GDAL in create_mask_band

### DIFF
--- a/lib/gdal/dataset/raster_band_methods.rb
+++ b/lib/gdal/dataset/raster_band_methods.rb
@@ -15,7 +15,7 @@ module GDAL
           result | case flag
                    when :GMF_ALL_VALID then 0x01
                    when :GMF_PER_DATASET then 0x02
-                   when :GMF_PER_ALPHA then 0x04
+                   when :GMF_PER_ALPHA, :GMF_ALPHA then 0x04
                    when :GMF_NODATA then 0x08
                    else 0
                    end
@@ -85,7 +85,7 @@ module GDAL
       # @param flags [Array<Symbol>, Symbol] Any of the :GMF symbols.
       # @raise [GDAL::Error]
       def create_mask_band(*flags)
-        flag_value = RasterBandMethods.parse_mask_flag_symbols(flags)
+        flag_value = RasterBandMethods.parse_mask_flag_symbols(*flags.flatten)
 
         GDAL::CPLErrorHandler.manually_handle("Unable to create Dataset mask band") do
           FFI::GDAL::GDAL.GDALCreateDatasetMaskBand(@c_pointer, flag_value)

--- a/lib/gdal/raster_band.rb
+++ b/lib/gdal/raster_band.rb
@@ -239,13 +239,11 @@ module GDAL
     # @param flags [Array<Symbol>, Symbol] Any of the :GMF symbols.
     # @raise [GDAL::Error]
     def create_mask_band(*flags)
-      flag_value = 0
-
-      flag_value = flags.each_with_object(flag_value) do |flag, result|
-        result + case flag
+      flag_value = flags.flatten.reduce(0) do |result, flag|
+        result | case flag
                  when :GMF_ALL_VALID then 0x01
                  when :GMF_PER_DATASET then 0x02
-                 when :GMF_PER_ALPHA then 0x04
+                 when :GMF_PER_ALPHA, :GMF_ALPHA then 0x04
                  when :GMF_NODATA then 0x08
                  else 0
                  end

--- a/spec/integration/gdal/dataset_info_spec.rb
+++ b/spec/integration/gdal/dataset_info_spec.rb
@@ -119,33 +119,50 @@ RSpec.describe "Dataset Info", type: :integration do
   end
 
   describe "#create_mask_band" do
+    # NOTE: A dataset-level mask is per-dataset by definition, so GDAL ORs
+    # GMF_PER_DATASET into whatever flags are requested.
     context ":GMF_ALL_VALID" do
-      it "does not raise" do
+      it "creates a mask band with the requested flag" do
         expect(subject.create_mask_band(:GMF_ALL_VALID)).to be_nil
+        expect(subject.raster_band(1).mask_flags).to eq(%i[GMF_ALL_VALID GMF_PER_DATASET])
       end
     end
 
     context ":GMF_PER_DATASET" do
-      it "does not raise" do
+      it "creates a mask band with the requested flag" do
         expect(subject.create_mask_band(:GMF_PER_DATASET)).to be_nil
+        expect(subject.raster_band(1).mask_flags).to eq([:GMF_PER_DATASET])
       end
     end
 
     context ":GMF_PER_ALPHA" do
-      it "does not raise" do
+      it "creates a mask band with the requested flag" do
         expect(subject.create_mask_band(:GMF_PER_ALPHA)).to be_nil
+
+        # NOTE: GDAL's constant for this bit is GMF_ALPHA (there is no
+        # GMF_PER_ALPHA in gdal.h), so #mask_flags reports it as :GMF_ALPHA.
+        expect(subject.raster_band(1).mask_flags).to eq(%i[GMF_PER_DATASET GMF_ALPHA])
       end
     end
 
     context ":GMF_NODATA" do
-      it "does not raise" do
+      it "creates a mask band with the requested flag" do
         expect(subject.create_mask_band(:GMF_NODATA)).to be_nil
+        expect(subject.raster_band(1).mask_flags).to eq(%i[GMF_PER_DATASET GMF_NODATA])
       end
     end
 
     context "all flags" do
-      it "does not raise" do
+      it "creates a mask band with the requested flags" do
         expect(subject.create_mask_band(:GMF_ALL_VALID, :GMF_PER_DATASET, :GMF_PER_ALPHA, :GMF_NODATA)).to be_nil
+        expect(subject.raster_band(1).mask_flags).to eq(%i[GMF_ALL_VALID GMF_PER_DATASET GMF_ALPHA GMF_NODATA])
+      end
+    end
+
+    context "flags passed as an Array" do
+      it "creates a mask band with the requested flag" do
+        expect(subject.create_mask_band([:GMF_PER_DATASET])).to be_nil
+        expect(subject.raster_band(1).mask_flags).to eq([:GMF_PER_DATASET])
       end
     end
   end

--- a/spec/integration/gdal/raster_band_info_spec.rb
+++ b/spec/integration/gdal/raster_band_info_spec.rb
@@ -175,6 +175,61 @@ RSpec.describe "Raster Band Info", type: :integration do
     end
   end
 
+  describe "#create_mask_band" do
+    context ":GMF_ALL_VALID" do
+      it "creates a mask band with the requested flag" do
+        expect(subject.create_mask_band(:GMF_ALL_VALID)).to be_nil
+        expect(subject.mask_flags).to eq([:GMF_ALL_VALID])
+      end
+    end
+
+    context ":GMF_PER_DATASET" do
+      it "creates a mask band with the requested flag" do
+        expect(subject.create_mask_band(:GMF_PER_DATASET)).to be_nil
+        expect(subject.mask_flags).to eq([:GMF_PER_DATASET])
+      end
+    end
+
+    context ":GMF_PER_ALPHA" do
+      it "creates a mask band with the requested flag" do
+        expect(subject.create_mask_band(:GMF_PER_ALPHA)).to be_nil
+
+        # NOTE: GDAL's constant for this bit is GMF_ALPHA (there is no
+        # GMF_PER_ALPHA in gdal.h); :GMF_PER_ALPHA is historical
+        # ffi-gdal naming on the create_mask_band input side.
+        expect(subject.mask_flags).to eq([:GMF_ALPHA])
+      end
+    end
+
+    context ":GMF_ALPHA" do
+      it "creates a mask band with the requested flag" do
+        expect(subject.create_mask_band(:GMF_ALPHA)).to be_nil
+        expect(subject.mask_flags).to eq([:GMF_ALPHA])
+      end
+    end
+
+    context ":GMF_NODATA" do
+      it "creates a mask band with the requested flag" do
+        expect(subject.create_mask_band(:GMF_NODATA)).to be_nil
+        expect(subject.mask_flags).to eq([:GMF_NODATA])
+      end
+    end
+
+    context "all flags" do
+      it "creates a mask band with the requested flags" do
+        expect(subject.create_mask_band(:GMF_ALL_VALID, :GMF_PER_DATASET, :GMF_PER_ALPHA, :GMF_NODATA)).to be_nil
+        expect(subject.mask_flags).to eq(%i[GMF_ALL_VALID GMF_PER_DATASET GMF_ALPHA GMF_NODATA])
+      end
+    end
+
+    context "flags passed as an Array" do
+      it "creates a mask band with the requested flags" do
+        expect(subject.create_mask_band(%i[GMF_ALL_VALID GMF_NODATA])).to be_nil
+        expect(subject.mask_flags).to eq(%i[GMF_ALL_VALID GMF_NODATA])
+      end
+    end
+  end
+
   describe "#statistics" do
     it "returns a Hash with populated values" do
       expect(subject.statistics).to be_a Hash

--- a/spec/unit/gdal/dataset/raster_band_methods_spec.rb
+++ b/spec/unit/gdal/dataset/raster_band_methods_spec.rb
@@ -25,8 +25,20 @@ RSpec.describe GDAL::Dataset::RasterBandMethods do
     end
 
     context ":GMF_ALL_VALID, :GMF_NODATA" do
-      it "returns 1" do
+      it "returns 9 (the flag bits ORed together)" do
         expect(described_class.parse_mask_flag_symbols(:GMF_ALL_VALID, :GMF_NODATA)).to eq 9
+      end
+    end
+
+    context ":GMF_PER_ALPHA" do
+      it "returns 4" do
+        expect(described_class.parse_mask_flag_symbols(:GMF_PER_ALPHA)).to eq 4
+      end
+    end
+
+    context ":GMF_ALPHA" do
+      it "returns 4 (GDAL's own name for the GMF_PER_ALPHA bit)" do
+        expect(described_class.parse_mask_flag_symbols(:GMF_ALPHA)).to eq 4
       end
     end
   end


### PR DESCRIPTION
Both `create_mask_band` implementations silently sent flag value 0 to GDAL regardless of the symbols passed in:

- `GDAL::Dataset::RasterBandMethods#create_mask_band` forwarded its splatted args as an Array into `parse_mask_flag_symbols`, which splats again - so each element was an Array, never a Symbol, and fell through to 0.
- `GDAL::RasterBand#create_mask_band` summed flag bits inside `each_with_object`, which returns the memo object; with an immutable Integer memo, the computed sum was discarded, and 0 was returned.

I have added specs for all flags and a combination of flags to show that it's now working correctly.