### PR TITLE
test: adapt unit specs to GDAL 3.9-3.12 behavior changes

### DIFF
--- a/spec/unit/gdal/utils/dem/options_spec.rb
+++ b/spec/unit/gdal/utils/dem/options_spec.rb
@@ -32,9 +32,14 @@ RSpec.describe GDAL::Utils::DEM::Options do
     let(:options) { ["-unknown123"] }
 
     it "raises exception" do
-      expect { subject }.to raise_exception(
-        GDAL::UnsupportedOperation, "Unknown option name '-unknown123'"
-      )
+      expected_errors = [
+        [GDAL::Error, "Unexpected exception: Argument(s) are not valid with any processing mode."], # GDAL 3.10+
+        [GDAL::UnsupportedOperation, "Unknown option name '-unknown123'"] # GDAL < 3.10
+      ]
+
+      expect { subject }.to raise_exception(StandardError) do |error|
+        expect(expected_errors).to include([error.class, error.message])
+      end
     end
   end
 end

--- a/spec/unit/gdal/utils/dem_spec.rb
+++ b/spec/unit/gdal/utils/dem_spec.rb
@@ -57,15 +57,22 @@ RSpec.describe GDAL::Utils::DEM do
 
     context "when operation fails with GDAL internal exception" do
       it "raises exception" do
+        expected_messages = [
+          "Invalid processing mode: hillshade123", # GDAL 3.10+
+          "Invalid processing" # GDAL < 3.10
+        ]
+
+        # rubocop:disable Style/MultilineBlockChain
         expect do
           described_class.perform(
             dst_dataset_path: new_dataset_path,
             src_dataset: src_dataset,
             processing: "hillshade123"
           )
-        end.to raise_exception(
-          ArgumentError, "Invalid processing"
-        )
+        end.to raise_exception(ArgumentError) do |error|
+          expect(expected_messages).to include(error.message)
+        end
+        # rubocop:enable Style/MultilineBlockChain
       end
 
       it "raises exception" do

--- a/spec/unit/gdal/utils/grid/options_spec.rb
+++ b/spec/unit/gdal/utils/grid/options_spec.rb
@@ -32,9 +32,14 @@ RSpec.describe GDAL::Utils::Grid::Options do
     let(:options) { ["-unknown123"] }
 
     it "raises exception" do
-      expect { subject }.to raise_exception(
-        GDAL::UnsupportedOperation, "Unknown option name '-unknown123'"
-      )
+      expected_errors = [
+        [GDAL::Error, "Unknown argument: -unknown123"], # GDAL 3.9+
+        [GDAL::UnsupportedOperation, "Unknown option name '-unknown123'"] # GDAL < 3.9
+      ]
+
+      expect { subject }.to raise_exception(StandardError) do |error|
+        expect(expected_errors).to include([error.class, error.message])
+      end
     end
   end
 end

--- a/spec/unit/gdal/utils/info/options_spec.rb
+++ b/spec/unit/gdal/utils/info/options_spec.rb
@@ -32,9 +32,14 @@ RSpec.describe GDAL::Utils::Info::Options do
     let(:options) { ["-json123"] }
 
     it "raises exception" do
-      expect { subject }.to raise_exception(
-        GDAL::UnsupportedOperation, "Unknown option name '-json123'"
-      )
+      expected_errors = [
+        [GDAL::Error, "Unknown argument: -json123"], # GDAL 3.9+
+        [GDAL::UnsupportedOperation, "Unknown option name '-json123'"] # GDAL < 3.9
+      ]
+
+      expect { subject }.to raise_exception(StandardError) do |error|
+        expect(expected_errors).to include([error.class, error.message])
+      end
     end
   end
 end

--- a/spec/unit/gdal/utils/nearblack/options_spec.rb
+++ b/spec/unit/gdal/utils/nearblack/options_spec.rb
@@ -32,9 +32,14 @@ RSpec.describe GDAL::Utils::Nearblack::Options do
     let(:options) { ["-unknown123"] }
 
     it "raises exception" do
-      expect { subject }.to raise_exception(
-        GDAL::UnsupportedOperation, "Unknown option name '-unknown123'"
-      )
+      expected_errors = [
+        [GDAL::Error, "Unknown argument: -unknown123"], # GDAL 3.9+
+        [GDAL::UnsupportedOperation, "Unknown option name '-unknown123'"] # GDAL < 3.9
+      ]
+
+      expect { subject }.to raise_exception(StandardError) do |error|
+        expect(expected_errors).to include([error.class, error.message])
+      end
     end
   end
 end

--- a/spec/unit/gdal/utils/rasterize/options_spec.rb
+++ b/spec/unit/gdal/utils/rasterize/options_spec.rb
@@ -32,9 +32,14 @@ RSpec.describe GDAL::Utils::Rasterize::Options do
     let(:options) { ["-unknown123"] }
 
     it "raises exception" do
-      expect { subject }.to raise_exception(
-        GDAL::UnsupportedOperation, "Unknown option name '-unknown123'"
-      )
+      expected_errors = [
+        [GDAL::Error, "Unknown argument: -unknown123"], # GDAL 3.10+
+        [GDAL::UnsupportedOperation, "Unknown option name '-unknown123'"] # GDAL < 3.10
+      ]
+
+      expect { subject }.to raise_exception(StandardError) do |error|
+        expect(expected_errors).to include([error.class, error.message])
+      end
     end
   end
 end

--- a/spec/unit/gdal/utils/rasterize_spec.rb
+++ b/spec/unit/gdal/utils/rasterize_spec.rb
@@ -18,9 +18,18 @@ RSpec.describe GDAL::Utils::Rasterize do
 
     context "when no options are provided" do
       it "raises exceptions (size or resolution must be provided)" do
+        expected_messages = [
+          "Size and resolution are missing", # GDAL 3.11+
+          "Size and resolutions are missing" # GDAL < 3.11
+        ]
+
+        # rubocop:disable Style/MultilineBlockChain
         expect do
           described_class.perform(dst_dataset_path: new_dataset_path, src_dataset: src_dataset)
-        end.to raise_exception(GDAL::Error, "Size and resolutions are missing")
+        end.to raise_exception(GDAL::Error) do |error|
+          expect(expected_messages).to include(error.message)
+        end
+        # rubocop:enable Style/MultilineBlockChain
       end
     end
 

--- a/spec/unit/gdal/utils/translate/options_spec.rb
+++ b/spec/unit/gdal/utils/translate/options_spec.rb
@@ -32,9 +32,14 @@ RSpec.describe GDAL::Utils::Translate::Options do
     let(:options) { ["-unscale123"] }
 
     it "raises exception" do
-      expect { subject }.to raise_exception(
-        GDAL::UnsupportedOperation, "Unknown option name '-unscale123'"
-      )
+      expected_errors = [
+        [GDAL::Error, "Unknown argument: -unscale123"], # GDAL 3.9+
+        [GDAL::UnsupportedOperation, "Unknown option name '-unscale123'"] # GDAL < 3.9
+      ]
+
+      expect { subject }.to raise_exception(StandardError) do |error|
+        expect(expected_errors).to include([error.class, error.message])
+      end
     end
   end
 end

--- a/spec/unit/gdal/utils/vector_translate/options_spec.rb
+++ b/spec/unit/gdal/utils/vector_translate/options_spec.rb
@@ -32,9 +32,14 @@ RSpec.describe GDAL::Utils::VectorTranslate::Options do
     let(:options) { ["-overwrite123"] }
 
     it "raises exception" do
-      expect { subject }.to raise_exception(
-        GDAL::UnsupportedOperation, "Unknown option name '-overwrite123'"
-      )
+      expected_errors = [
+        [GDAL::Error, "Unknown argument: -overwrite123"], # GDAL 3.9+
+        [GDAL::UnsupportedOperation, "Unknown option name '-overwrite123'"] # GDAL < 3.9
+      ]
+
+      expect { subject }.to raise_exception(StandardError) do |error|
+        expect(expected_errors).to include([error.class, error.message])
+      end
     end
   end
 end

--- a/spec/unit/gdal/utils/warp/options_spec.rb
+++ b/spec/unit/gdal/utils/warp/options_spec.rb
@@ -32,9 +32,14 @@ RSpec.describe GDAL::Utils::Warp::Options do
     let(:options) { ["-multi123"] }
 
     it "raises exception" do
-      expect { subject }.to raise_exception(
-        GDAL::UnsupportedOperation, "Unknown option name '-multi123'"
-      )
+      expected_errors = [
+        [GDAL::Error, "Unknown argument: -multi123"], # GDAL 3.9+
+        [GDAL::UnsupportedOperation, "Unknown option name '-multi123'"] # GDAL < 3.9
+      ]
+
+      expect { subject }.to raise_exception(StandardError) do |error|
+        expect(expected_errors).to include([error.class, error.message])
+      end
     end
   end
 end

--- a/spec/unit/ogr/driver_spec.rb
+++ b/spec/unit/ogr/driver_spec.rb
@@ -119,11 +119,18 @@ RSpec.describe OGR::Driver do
   end
 
   describe "#delete_data_source" do
-    context "does not support deleting" do
-      context "data source does not exist" do
-        it "raises a OGR::UnsupportedOperation (Memory driver doesn't support)" do
-          expect { subject.delete_data_source("we no here") }.to raise_exception OGR::UnsupportedOperation
-        end
+    context "data source does not exist" do
+      # GDAL 3.11 aliased the Memory driver to the MEM driver, which supports deleting.
+      it "raises a OGR::UnsupportedOperation (Memory driver doesn't support deleting)" do
+        skip "GDAL 3.11+ Memory driver supports deleting" if GDAL.version_num >= "3110000"
+
+        expect { subject.delete_data_source("we no here") }.to raise_exception OGR::UnsupportedOperation
+      end
+
+      it "does not raise (Memory driver supports deleting)" do
+        skip "This spec only for GDAL 3.11+" if GDAL.version_num < "3110000"
+
+        expect { subject.delete_data_source("we no here") }.not_to raise_exception
       end
     end
   end

--- a/spec/unit/ogr/extensions/driver/capability_methods_spec.rb
+++ b/spec/unit/ogr/extensions/driver/capability_methods_spec.rb
@@ -14,7 +14,10 @@ RSpec.describe OGR::Driver do
 
     describe "#can_delete_data_source?" do
       subject { driver.can_delete_data_source? }
-      it { is_expected.to eq false }
+
+      # GDAL 3.11 aliased the Memory driver to the MEM driver, which
+      # advertises DeleteDataSource support.
+      it { is_expected.to eq(GDAL.version_num >= "3110000") }
     end
   end
 end


### PR DESCRIPTION
CI matrix currently tops out at GDAL 3.8.4 (ubuntu-24.04), so these changes only surface on newer stacks, but they landed across 3.9-3.11:

- GDAL 3.9 adopted `GDALArgumentParser` for `gdalinfo`, `gdal_translate`, `gdalwarp`, `gdal_grid`, `nearblack` and `ogr2ogr`; GDAL 3.10 for `gdaldem` and `gdal_rasterize`. Unknown options now raise `GDAL::Error` "Unknown argument: -x" instead of `GDAL::UnsupportedOperation` "Unknown option name '-x'": accept both variants in the eight `GDAL::Utils::*::Options` specs.
- GDAL 3.11 aliased the `OGR Memory` driver to the `MEM` driver, which advertises and supports `DeleteDataSource`.
- Message drift: `gdaldem` appends the mode to "Invalid processing" (3.10), `gdal_rasterize` dropped the stray plural in "Size and resolution(s) are missing" (3.11).