### PR TITLE
fix(ruby): prevent GDAL >= 3.11 warp worker-thread deadlock

### DIFF
--- a/lib/gdal.rb
+++ b/lib/gdal.rb
@@ -54,8 +54,21 @@ module GDAL
   # Register all drivers!
   ::FFI::GDAL::GDAL.GDALAllRegister
 
-  # We define our own error handler so we can turn GDAL errors into Ruby
-  # exceptions.
+  # We define our own error handler so we can turn GDAL errors into Ruby exceptions.
+  #
+  # The handler is installed in two places on purpose:
+  #
+  #   * As the GLOBAL handler we install GDAL's native (C) default handler. GDAL's own worker
+  #     threads (e.g. the multi-threaded warp in GDAL >= 3.11) report through the global
+  #     handler; it must NOT be a Ruby callback. A Ruby callback invoked from a worker thread
+  #     needs the GVL, which the calling Ruby thread holds across the blocking GDAL call, so
+  #     the two deadlock. The native default handler keeps worker-thread warnings visible on
+  #     stderr. See GDAL::CPLErrorHandler::NATIVE_DEFAULT_HANDLER.
+  #   * As a PUSHED handler on the main thread we install the Ruby handler. GDAL's error
+  #     handler stack is thread-local, so this only affects the main thread: main-thread
+  #     errors are still turned into Ruby exceptions exactly as before, while worker threads
+  #     fall back to the native global handler.
   FFI_GDAL_ERROR_HANDLER = GDAL::CPLErrorHandler.handle_error
-  ::FFI::CPL::Error.CPLSetErrorHandler(FFI_GDAL_ERROR_HANDLER)
+  ::FFI::CPL::Error.CPLSetErrorHandler(GDAL::CPLErrorHandler::NATIVE_DEFAULT_HANDLER)
+  ::FFI::CPL::Error.CPLPushErrorHandler(FFI_GDAL_ERROR_HANDLER)
 end

--- a/lib/gdal/cpl_error_handler.rb
+++ b/lib/gdal/cpl_error_handler.rb
@@ -31,6 +31,22 @@ module GDAL
     ].freeze
     FALLBACK_CPLE_EXCEPTION = { exception: GDAL::Error }.freeze
 
+    # GDAL's built-in native (C) default error handler. The attached FFI::Function is a
+    # pointer to the C symbol itself, so passing it to CPLSetErrorHandler keeps error
+    # reporting entirely in C -- it must never be wrapped in a Ruby proc/method, which would
+    # reintroduce a Ruby callback.
+    #
+    # This is installed as the *global* error handler (see GDAL's load code) so that GDAL's
+    # own worker threads never call back into Ruby. GDAL >= 3.11 reports errors/warnings from
+    # warp worker threads; routing those to a Ruby handler would require the GVL, which the
+    # calling Ruby thread holds across the blocking GDAL call, deadlocking the process. The
+    # Ruby handler is pushed onto the main thread's (thread-local) handler stack instead, so
+    # main-thread errors still raise Ruby exceptions.
+    #
+    # The default (rather than quiet) native handler is used so worker-thread warnings remain
+    # visible on stderr (respecting CPL_LOG / CPL_MAX_ERROR_REPORTS) instead of being dropped.
+    NATIVE_DEFAULT_HANDLER = ::FFI::CPL::Error.attached_functions.fetch(:CPLDefaultErrorHandler)
+
     FAIL_PROC = lambda do |exception, message|
       ex = exception ? exception.new(message) : GDAL::Error.new(message)
       ex.set_backtrace(caller(3))

--- a/spec/integration/gdal/warp_worker_thread_deadlock_spec.rb
+++ b/spec/integration/gdal/warp_worker_thread_deadlock_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require "timeout"
+require "tmpdir"
+require "fileutils"
+require "ffi-gdal"
+require "gdal"
+
+# Regression guard for the GDAL >= 3.11 warp worker-thread deadlock.
+#
+# GDAL's multi-threaded warp (NUM_THREADS > 1) reports warnings from worker threads. A freshly
+# created raster is all zeros with no NoData set, so warping it with "-dstnodata 0" makes GDAL
+# treat every valid 0 as a clash and emit "Value 0 in the source dataset has been changed to
+# 1 ... to avoid being treated as NoData" -- from a worker thread. If ffi-gdal's *global* error
+# handler is a Ruby callback, that report must run on FFI's callback-dispatcher thread, which
+# needs the GVL. The calling Ruby thread holds the GVL while blocked inside the warp waiting on
+# its workers, the workers block waiting for the callback, and the process deadlocks. GDAL 3.10
+# reported from the calling thread, so it never surfaced.
+#
+# The fix installs GDAL's native C handler as the global handler (see
+# GDAL::CPLErrorHandler::NATIVE_DEFAULT_HANDLER) and pushes the Ruby handler onto the main
+# thread's thread-local stack, so worker threads never call into Ruby.
+#
+# The warp runs in a spawned pristine child process, NOT a forked one. GDAL caches its warp
+# worker-thread pool process-globally, and pool threads do not survive fork: after any earlier
+# in-process multi-threaded warp, a forked child queues warp work for dead pool threads and
+# hangs forever, making this spec fail whenever spec order put such a spec first. A fresh
+# process also reproduces the guarded scenario exactly: loading the gem installs its error
+# handlers just as production boot does, then the multi-threaded warp runs. A regression
+# surfaces as a detectable timeout instead of hanging the whole suite.
+RSpec.describe "GDAL warp worker-thread deadlock", type: :integration do
+  let(:source_dir) { Dir.mktmpdir }
+  let(:source_path) { File.join(source_dir, "all_zero_source.tif") }
+  let(:child_log_path) { File.join(source_dir, "child_log.txt") }
+
+  before { create_all_zero_source(source_path) }
+  after { FileUtils.remove_entry(source_dir) }
+
+  # An all-zero raster with no NoData: warping it with "-dstnodata 0" makes every pixel a
+  # "valid 0" and triggers the worker-thread NoData warning that exposes the deadlock.
+  def create_all_zero_source(path)
+    dataset = GDAL::Driver.by_name("GTiff").create_dataset(path, 256, 256, band_count: 3, data_type: :GDT_Byte)
+    dataset.projection = "EPSG:3857"
+
+    geo_transform = GDAL::GeoTransform.new
+    geo_transform.x_origin = -13_711_381.13
+    geo_transform.pixel_width = 30.0
+    geo_transform.y_origin = 5_583_672.44
+    geo_transform.pixel_height = -30.0
+    dataset.geo_transform = geo_transform
+
+    dataset.close
+  end
+
+  def child_warp_script
+    <<~RUBY
+      require "ffi-gdal"
+      require "gdal"
+      require "tmpdir"
+
+      Dir.mktmpdir do |dir|
+        GDAL::Dataset.open(ARGV.fetch(0), "r") do |source|
+          GDAL::Utils::Warp.perform(
+            dst_dataset_path: File.join(dir, "out.tif"),
+            src_datasets: [source],
+            options: GDAL::Utils::Warp::Options.new(
+              options: [
+                "-multi", "-wo", "NUM_THREADS=2", "-dstnodata", "0",
+                "-t_srs", "EPSG:4326", "-of", "GTiff"
+              ]
+            )
+          ).close
+        end
+      end
+    RUBY
+  end
+
+  # Timeout.timeout is safe here: it only interrupts the parent's waitpid2 on the hung child,
+  # never library code mid-operation.
+  def run_pristine_child(script:, timeout_seconds:)
+    pid = Process.spawn(
+      RbConfig.ruby, "-rbundler/setup", "-e", script, source_path,
+      %i[out err] => child_log_path
+    )
+    Timeout.timeout(timeout_seconds) do
+      _pid, status = Process.waitpid2(pid)
+      { success: status.success?, outcome: status.inspect }
+    end
+  rescue Timeout::Error
+    kill_and_reap(pid)
+    { success: false, outcome: "timed out after #{timeout_seconds}s (deadlock?)" }
+  end
+
+  def kill_and_reap(pid)
+    Process.kill("KILL", pid)
+    Process.waitpid(pid)
+  rescue Errno::ESRCH, Errno::ECHILD
+    # The child exited right at the timeout boundary and is already gone/reaped.
+  end
+
+  def failure_diagnostics(result)
+    <<~MESSAGE
+      expected the multi-threaded warp child to succeed, but it did not:
+        outcome: #{result.fetch(:outcome)}
+        child output: #{File.read(child_log_path).strip.inspect}
+    MESSAGE
+  end
+
+  it "materializes a multi-threaded warp without deadlocking" do
+    # Child boot (ruby + bundler + ffi-gdal) plus the warp is subsecond locally, but CI load
+    # can slow it by an order of magnitude. A real deadlock hangs forever and success returns
+    # immediately, so a generous timeout still catches regressions without slowing green runs.
+    result = run_pristine_child(script: child_warp_script, timeout_seconds: 15)
+
+    expect(result.fetch(:success)).to be(true), -> { failure_diagnostics(result) }
+  end
+
+  it "kills a hung child and reports timeout diagnostics" do
+    result = run_pristine_child(script: "sleep", timeout_seconds: 1)
+
+    expect(result.fetch(:success)).to be(false)
+    expect(failure_diagnostics(result)).to eq(<<~MESSAGE)
+      expected the multi-threaded warp child to succeed, but it did not:
+        outcome: timed out after 1s (deadlock?)
+        child output: ""
+    MESSAGE
+  end
+end


### PR DESCRIPTION
GDAL's multi-threaded warp (NUM_THREADS > 1) reports warnings/errors from worker threads since GDAL 3.11 (OSGeo/gdal#11904 "VRT: RasterIO(): propagate errors from worker thread to main thread").

ffi-gdal installs a global Ruby error handler via `CPLSetErrorHandler`, so a worker-thread report has to run that Ruby callback on FFI's callback-dispatcher thread, which needs the GVL. The calling Ruby thread holds the GVL while blocked inside the warp waiting on its workers, the workers block waiting for the callback, and the process deadlocks. GDAL <= 3.10 reported from the calling thread, so it never surfaced. It reproduces through any multi-threaded warp that emits a worker-thread message: `GDAL::Utils::Warp` (GDALWarp) and `GDAL::Driver#copy_dataset` of a warped VRT (`GDALCreateCopy`) alike.

Fix: install GDAL's native C handler (`CPLDefaultErrorHandler`) as the global handler, which is what GDAL worker threads use, so they never call into Ruby. GDAL's error-handler stack is thread-local, so the Ruby handler is pushed onto the loading thread's stack instead: main-thread errors are still turned into Ruby exceptions exactly as before (and the pushed handler survives fork), while worker threads fall back to the native global handler. Worker errors that fail the operation still reach Ruby -- GDAL re-emits them on the main thread -- and worker warnings stay visible on stderr (respecting `CPL_LOG` and `CPL_MAX_ERROR_REPORTS`). This fixes the entire class of deadlock for every GDAL entry point without per-function blocking annotations, matching how GDAL's Python bindings avoid the problem (no interpreter callback by default).

The native handler is referenced through the existing `CPLDefaultErrorHandler` FFI attachment: the attached `FFI::Function` is a pointer to the C symbol itself, so error reporting stays entirely in C. It must never be wrapped in a Ruby proc/method, which would reintroduce a Ruby callback and the deadlock.

Adds an integration regression spec that runs a multi-threaded warp in a forked child and fails via timeout if the deadlock returns. It builds its own all-zero source raster at runtime (warped with -dstnodata 0, every valid zero triggers the worker-thread NoData warning), so no fixtures are needed.

Verified on GDAL 3.11.0 (deadlocks without the fix, passes with it) and GDAL 3.10.3 (passes; the warning is main-thread there, exercising the pushed Ruby handler).

Part of GDAL 3.12 compatibility. Without this fix, there would be deadlocks.