### PR TITLE
chore: modernize rubocop tooling + config (part 1 of 2)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,8 +5,10 @@ inherit_mode:
   merge:
     - Exclude
 
-require:
+plugins:
   - rubocop-performance
+  - rubocop-rspec
+  - rubocop-rake
 
 Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,6 +62,95 @@ Style/ArgumentsForwarding:
 Naming/BlockForwarding:
   Enabled: false
 
+# --- rubocop-rspec: opinionated cops disabled for this suite ---------------
+# The existing ~130-file spec suite predates rubocop-rspec. These cops are
+# stylistic/structural preferences whose autocorrection or manual churn would
+# touch thousands of lines for no behavioral gain, so they are disabled with
+# rationale rather than suppressed in a regenerated todo file.
+#
+# The five threshold cops below (MultipleExpectations, NestedGroups,
+# MultipleMemoizedHelpers, ExampleLength, ContextWording) are candidates to
+# reconsider later — configuring a Max/Prefixes value instead of a flat disable.
+
+# TODO: revisit — candidate to configure with a Max instead of disabling.
+RSpec/MultipleExpectations:
+  Enabled: false
+
+# TODO: revisit — candidate to configure with a Max instead of disabling.
+RSpec/NestedGroups:
+  Enabled: false
+
+# TODO: revisit — candidate to configure with a Max instead of disabling.
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
+# TODO: revisit — candidate to configure with a Max instead of disabling.
+RSpec/ExampleLength:
+  Enabled: false
+
+# TODO: revisit — candidate to configure with Prefixes instead of disabling.
+RSpec/ContextWording:
+  Enabled: false
+
+# The suite relies on the implicit `subject` throughout; naming every one would
+# be pure churn.
+RSpec/NamedSubject:
+  Enabled: false
+
+# Spec files are organized by mixin/method-group (e.g. `dataset/accessors_spec`
+# covering `GDAL::Dataset`, `extensions/*`) mirroring `lib/`; enforcing a
+# path-matches-described-class rule would require restructuring the suite.
+RSpec/SpecFilePathFormat:
+  Enabled: false
+
+# Shared examples conditionally `skip` geometry types unsupported by some GDAL
+# builds — intentional, not missing reasons.
+RSpec/PendingWithoutReason:
+  Enabled: false
+
+# The suite mixes `have_received` spies and `expect(...).to receive` freely;
+# enforcing one style is not worth the churn.
+RSpec/MessageSpies:
+  Enabled: false
+
+# Numbered `let`s (let1/let2) are used deliberately in several data-driven specs.
+RSpec/IndexedLet:
+  Enabled: false
+
+# These thin FFI wrappers are legitimately stubbed on their own subject.
+RSpec/SubjectStub:
+  Enabled: false
+
+# Setting an expectation on a stubbed message is an intentional pattern here.
+RSpec/StubbedMock:
+  Enabled: false
+
+# Repeated example-group bodies are shared structural patterns across the
+# FFI-binding specs; the cop is false-positive-prone on them.
+RSpec/RepeatedExampleGroupBody:
+  Enabled: false
+
+# Some setup hooks legitimately assert preconditions before the examples run.
+RSpec/ExpectInHook:
+  Enabled: false
+
+# Several specs use feature-oriented `describe "..."` strings rather than a class.
+RSpec/DescribeClass:
+  Enabled: false
+
+# `any_instance_of` is required to mock across the FFI boundary in some specs.
+RSpec/AnyInstance:
+  Enabled: false
+
+# `let!` used purely for its side effect is intentional in a few specs.
+RSpec/LetSetup:
+  Enabled: false
+
+# The suite uses plain (non-verifying) doubles by design in a few places.
+RSpec/VerifiedDoubles:
+  Enabled: false
+# --------------------------------------------------------------------------
+
 AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,16 @@ Naming/MethodParameterName:
 Style/Documentation:
   Enabled: false
 
+# These files legitimately define more than one constant in a single file:
+# `numeric_as_data_type.rb`/`to_bool.rb` reopen several core classes to attach
+# the same extension, and `gdal.rb` defines the GDAL module alongside its
+# error-handling class. Splitting them would fragment cohesive units.
+Style/OneClassPerFile:
+  Exclude:
+    - lib/ext/numeric_as_data_type.rb
+    - lib/ext/to_bool.rb
+    - lib/gdal.rb
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 

--- a/Gemfile
+++ b/Gemfile
@@ -19,11 +19,13 @@ group :lint do
   # Ruby 4.0 removed `benchmark` from default gems; rubocop's executable
   # requires it, so rubocop can't run at all under Ruby 4.0 without this.
   gem "benchmark"
-  # TODO: Upgrade rubocop/rubocop-performance. These are pinned to old
-  # versions because bumping them pulls in ~100+ new cop violations that
-  # haven't been triaged yet. Now that we've dropped Ruby < 3.4, there's no
-  # longer a Ruby-version reason to hold back — this is purely deferred
-  # cleanup work.
-  gem "rubocop", "<= 1.63.1"
-  gem "rubocop-performance", "<= 1.24.0"
+  # RuboCop stack is now current. Gemfile.lock is gitignored (gem convention),
+  # so these EXACT pins are what keep CI reproducible and prevent a rubocop
+  # minor from silently adding cops (NewCops: enable) and breaking a green
+  # build with no code change. Upgrades are deliberate: bump the pin in a
+  # reviewed PR.
+  gem "rubocop", "= 1.88.2"
+  gem "rubocop-performance", "= 1.26.1"
+  gem "rubocop-rake", "= 0.7.1"
+  gem "rubocop-rspec", "= 3.10.2"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -31,5 +31,5 @@ namespace :spec do
 end
 
 desc "Run all specs (unit and integration)"
-task(:spec) { RSpec::Core::RakeTask.new }
+task spec: %w[spec:unit spec:integration]
 task default: :spec

--- a/Rakefile
+++ b/Rakefile
@@ -30,5 +30,6 @@ namespace :spec do
   end
 end
 
+desc "Run all specs (unit and integration)"
 task(:spec) { RSpec::Core::RakeTask.new }
 task default: :spec

--- a/examples/ogr_layer_to_layer.rb
+++ b/examples/ogr_layer_to_layer.rb
@@ -4,6 +4,7 @@ require "bundler/setup"
 require "ffi-gdal"
 
 include GDAL::Logger # rubocop:disable Style/MixinUsage
+
 GDAL::Logger.logging_enabled = true
 
 # http://pcjericks.github.io/py-gdalogr-cookbook/vector_layers.html#create-a-new-layer-from-the-extent-of-an-existing-layer

--- a/lib/ffi/cpl/conv.rb
+++ b/lib/ffi/cpl/conv.rb
@@ -7,6 +7,7 @@ module FFI
   module CPL
     module Conv
       extend ::FFI::Library
+
       ffi_lib [FFI::CURRENT_PROCESS, FFI::GDAL.gdal_library_path]
 
       #-------------------------------------------------------------------------

--- a/lib/ffi/cpl/error.rb
+++ b/lib/ffi/cpl/error.rb
@@ -6,6 +6,7 @@ module FFI
   module CPL
     module Error
       extend ::FFI::Library
+
       ffi_lib [FFI::CURRENT_PROCESS, FFI::GDAL.gdal_library_path]
 
       #------------------------------------------------------------------------

--- a/lib/ffi/cpl/hash_set.rb
+++ b/lib/ffi/cpl/hash_set.rb
@@ -7,6 +7,7 @@ module FFI
   module CPL
     module HashSet
       extend ::FFI::Library
+
       ffi_lib [FFI::CURRENT_PROCESS, FFI::GDAL.gdal_library_path]
 
       #-------------------------------------------------------------------------

--- a/lib/ffi/cpl/http.rb
+++ b/lib/ffi/cpl/http.rb
@@ -8,6 +8,7 @@ module FFI
   module CPL
     module HTTP
       extend ::FFI::Library
+
       ffi_lib [FFI::CURRENT_PROCESS, FFI::GDAL.gdal_library_path]
 
       #-------------------------------------------------------------------------

--- a/lib/ffi/cpl/list.rb
+++ b/lib/ffi/cpl/list.rb
@@ -15,6 +15,7 @@ module FFI
 
         module ClassMethods
           extend ::FFI::Library
+
           ffi_lib [FFI::CURRENT_PROCESS, FFI::GDAL.gdal_library_path]
 
           #-------------------------------------------------------------------

--- a/lib/ffi/cpl/minixml.rb
+++ b/lib/ffi/cpl/minixml.rb
@@ -7,6 +7,7 @@ module FFI
   module CPL
     module MiniXML
       extend ::FFI::Library
+
       ffi_lib [::FFI::CURRENT_PROCESS, ::FFI::GDAL.gdal_library_path]
 
       #-------------------------------------------------------------------------

--- a/lib/ffi/cpl/port.rb
+++ b/lib/ffi/cpl/port.rb
@@ -6,6 +6,7 @@ module FFI
   module CPL
     module Port
       extend ::FFI::Library
+
       ffi_lib [FFI::CURRENT_PROCESS, FFI::GDAL.gdal_library_path]
 
       #------------------------------------------------------------------------

--- a/lib/ffi/cpl/progress.rb
+++ b/lib/ffi/cpl/progress.rb
@@ -7,6 +7,7 @@ module FFI
   module CPL
     module Progress
       extend ::FFI::Library
+
       ffi_lib [FFI::CURRENT_PROCESS, FFI::GDAL.gdal_library_path]
 
       #-------------------------------------------------------------------------

--- a/lib/ffi/cpl/quad_tree.rb
+++ b/lib/ffi/cpl/quad_tree.rb
@@ -8,6 +8,7 @@ module FFI
   module CPL
     module QuadTree
       extend ::FFI::Library
+
       ffi_lib [FFI::CURRENT_PROCESS, FFI::GDAL.gdal_library_path]
 
       #-------------------------------------------------------------------------

--- a/lib/ffi/cpl/string.rb
+++ b/lib/ffi/cpl/string.rb
@@ -6,6 +6,7 @@ module FFI
   module CPL
     module String
       extend ::FFI::Library
+
       ffi_lib [::FFI::CURRENT_PROCESS, ::FFI::GDAL.gdal_library_path]
 
       #------------------------------------------------------------------------

--- a/lib/ffi/cpl/vsi.rb
+++ b/lib/ffi/cpl/vsi.rb
@@ -7,6 +7,7 @@ module FFI
   module CPL
     module VSI
       extend ::FFI::Library
+
       ffi_lib [FFI::CURRENT_PROCESS, FFI::GDAL.gdal_library_path]
 
       #------------------------------------------------------------------------

--- a/lib/ffi/gdal/alg.rb
+++ b/lib/ffi/gdal/alg.rb
@@ -7,6 +7,7 @@ module FFI
   module GDAL
     module Alg
       extend FFI::Library
+
       ffi_lib [::FFI::CURRENT_PROCESS, ::FFI::GDAL.gdal_library_path]
 
       # -----------------------------------------------------------------------

--- a/lib/ffi/gdal/gdal.rb
+++ b/lib/ffi/gdal/gdal.rb
@@ -9,6 +9,7 @@ module FFI
     # rubocop:disable Metrics/ModuleLength
     module GDAL
       extend ::FFI::Library
+
       ffi_lib [::FFI::CURRENT_PROCESS, ::FFI::GDAL.gdal_library_path]
 
       # ----------------------------------------------------------------

--- a/lib/ffi/gdal/grid.rb
+++ b/lib/ffi/gdal/grid.rb
@@ -7,6 +7,7 @@ module FFI
   module GDAL
     module Grid
       extend ::FFI::Library
+
       ffi_lib [::FFI::CURRENT_PROCESS, ::FFI::GDAL.gdal_library_path]
 
       #------------------------------------------------------------------------

--- a/lib/ffi/gdal/matching.rb
+++ b/lib/ffi/gdal/matching.rb
@@ -7,6 +7,7 @@ module FFI
   module GDAL
     module Matching
       extend ::FFI::Library
+
       ffi_lib [::FFI::CURRENT_PROCESS, ::FFI::GDAL.gdal_library_path]
 
       # TODO: Seems like this should return an array of GCPs, not just a single

--- a/lib/ffi/gdal/utils.rb
+++ b/lib/ffi/gdal/utils.rb
@@ -7,6 +7,7 @@ module FFI
   module GDAL
     module Utils
       extend FFI::Library
+
       ffi_lib [::FFI::CURRENT_PROCESS, ::FFI::GDAL.gdal_library_path]
 
       # -----------------------------------------------------------------------

--- a/lib/ffi/gdal/vrt.rb
+++ b/lib/ffi/gdal/vrt.rb
@@ -7,6 +7,7 @@ module FFI
   module GDAL
     module VRT
       extend ::FFI::Library
+
       ffi_lib [::FFI::CURRENT_PROCESS, ::FFI::GDAL.gdal_library_path]
 
       #-------------------------------------------------------------------------

--- a/lib/ffi/gdal/warper.rb
+++ b/lib/ffi/gdal/warper.rb
@@ -7,6 +7,7 @@ module FFI
   module GDAL
     module Warper
       extend ::FFI::Library
+
       ffi_lib [FFI::CURRENT_PROCESS, FFI::GDAL.gdal_library_path]
 
       #------------------------------------------------------------------------

--- a/lib/ffi/ogr/api.rb
+++ b/lib/ffi/ogr/api.rb
@@ -8,6 +8,7 @@ module FFI
   module OGR
     module API
       extend ::FFI::Library
+
       ffi_lib [::FFI::CURRENT_PROCESS, ::FFI::GDAL.gdal_library_path]
 
       # -----------------------------------------------------------------------

--- a/lib/ffi/ogr/core.rb
+++ b/lib/ffi/ogr/core.rb
@@ -9,6 +9,7 @@ module FFI
   module OGR
     module Core
       extend ::FFI::Library
+
       ffi_lib [::FFI::CURRENT_PROCESS, ::FFI::GDAL.gdal_library_path]
 
       #------------------------------------------------------------------------

--- a/lib/ffi/ogr/featurestyle.rb
+++ b/lib/ffi/ogr/featurestyle.rb
@@ -6,6 +6,7 @@ module FFI
   module OGR
     module Featurestyle
       extend ::FFI::Library
+
       ffi_lib [::FFI::CURRENT_PROCESS, ::FFI::GDAL.gdal_library_path]
 
       #------------------------------------------------------------------------

--- a/lib/ffi/ogr/geocoding.rb
+++ b/lib/ffi/ogr/geocoding.rb
@@ -7,6 +7,7 @@ module FFI
   module OGR
     module Geocoding
       extend ::FFI::Library
+
       ffi_lib [::FFI::CURRENT_PROCESS, ::FFI::GDAL.gdal_library_path]
 
       #------------------------------------------------------------------------

--- a/lib/ffi/ogr/srs_api.rb
+++ b/lib/ffi/ogr/srs_api.rb
@@ -8,6 +8,7 @@ module FFI
   module OGR
     module SRSAPI
       extend ::FFI::Library
+
       ffi_lib [::FFI::CURRENT_PROCESS, ::FFI::GDAL.gdal_library_path]
 
       # -----------------------------------------------------------------------

--- a/lib/gdal/dataset/algorithm_methods.rb
+++ b/lib/gdal/dataset/algorithm_methods.rb
@@ -23,7 +23,6 @@ module GDAL
       #   raster, suitable for heatmaps for instance.
       def rasterize_geometries!(band_numbers, geometries, burn_values,
         transformer: nil, transform_arg: nil, **options, &progress_block)
-
         if geo_transform.nil? && gcp_count.zero?
           raise "Can't rasterize geometries--no geo_transform or GCPs have been defined on the dataset."
         end

--- a/lib/gdal/driver.rb
+++ b/lib/gdal/driver.rb
@@ -184,6 +184,9 @@ module GDAL
     # @return [true]
     # @raise [GDAL::CreateFail] if it couldn't copy the dataset.
     # @yieldparam destination_dataset [GDAL::Dataset]
+    # Returns `true` on success; it's a command, not a query, so renaming it to
+    # a `?`-predicate would be a breaking public-API change.
+    # rubocop:disable Naming/PredicateMethod
     def copy_dataset(source_dataset, destination_path, progress_block = nil, progress_arg = nil, strict: true,
       **options)
       source_dataset_ptr = make_dataset_pointer(source_dataset)
@@ -211,6 +214,7 @@ module GDAL
 
       true
     end
+    # rubocop:enable Naming/PredicateMethod
 
     # Delete the dataset represented by +file_name+.  Depending on the driver,
     # this could mean deleting associated files, database objects, etc.

--- a/lib/gdal/extensions/raster_band/io_extensions.rb
+++ b/lib/gdal/extensions/raster_band/io_extensions.rb
@@ -39,8 +39,8 @@ module GDAL
             x_block_size = calculate_x_block_size(x_block_number)
 
             # Map the range of pixels corresponding to the current block.
-            source_x_range = x_block_number * block_size[:x]...(x_block_number * block_size[:x]) + x_block_size
-            source_y_range = y_block_number * block_size[:y]...(y_block_number * block_size[:y]) + y_block_size
+            source_x_range = (x_block_number * block_size[:x])...((x_block_number * block_size[:x]) + x_block_size)
+            source_y_range = (y_block_number * block_size[:y])...((y_block_number * block_size[:y]) + y_block_size)
 
             # Copy the corresponding pixels from the input array to the block pixels.
             block_pixels[0...y_block_size, 0...x_block_size] = pixel_array[source_y_range, source_x_range]

--- a/lib/gdal/raster_band_mixins/algorithm_methods.rb
+++ b/lib/gdal/raster_band_mixins/algorithm_methods.rb
@@ -95,7 +95,9 @@ module GDAL
       # @param x_size [Integer]
       # @param y_size [Integer]
       # @return [Integer] The checksum value.
-      def checksum_image(x_offset, y_offset, x_size, y_size)
+      # Command-style public API; renaming to a `?`-predicate would be a
+      # breaking change.
+      def checksum_image(x_offset, y_offset, x_size, y_size) # rubocop:disable Naming/PredicateMethod
         !!FFI::GDAL::Alg.GDALChecksumImage(
           @c_pointer,
           x_offset,
@@ -171,6 +173,9 @@ module GDAL
       #   +FFI::CPL::Progress.GDALCreateScaledProgress+.
       # @param options [Hash]
       # TODO: document what valid options are.
+      # Bang command returning a boolean success flag; renaming to a
+      # `?`-predicate would be a breaking public-API change.
+      # rubocop:disable Naming/PredicateMethod
       def fill_nodata!(mask_band, max_search_distance, smoothing_iterations, progress_function: nil, progress_arg: nil,
         **options)
         mask_band_ptr = GDAL._pointer(GDAL::RasterBand, mask_band)
@@ -185,6 +190,7 @@ module GDAL
                                         progress_function,
                                         progress_arg)
       end
+      # rubocop:enable Naming/PredicateMethod
 
       # Creates vector polygons for all connected regions of pixels in the raster
       # that share a common pixel value. Optionally, each polygon may be

--- a/lib/gdal/rpc_info.rb
+++ b/lib/gdal/rpc_info.rb
@@ -10,6 +10,7 @@ module GDAL
   # Wrapper for FFI::GDAL::RPCInfo.
   class RPCInfo
     extend Forwardable
+
     def_delegator :@c_struct, :[]
 
     # @param struct_or_ptr [FFI::GDAL::RPCInfo, FFI::Pointer]

--- a/lib/gdal/warp_operation.rb
+++ b/lib/gdal/warp_operation.rb
@@ -33,7 +33,9 @@ module GDAL
     # @param y_offset [Integer] Y offset of the destination image.
     # @param x_size [Integer] X size (width) of the destination image.
     # @param y_size [Integer] Y size (height) of the destination image.
-    def chunk_and_warp_image(x_offset, y_offset, x_size, y_size)
+    # Returns a boolean success flag; command-style public API, so renaming to
+    # a `?`-predicate would be a breaking change.
+    def chunk_and_warp_image(x_offset, y_offset, x_size, y_size) # rubocop:disable Naming/PredicateMethod
       !!FFI::GDAL::Warper.GDALChunkAndWarpImage(@c_pointer,
                                                 x_offset,
                                                 y_offset,
@@ -61,6 +63,9 @@ module GDAL
     # @param source_y_offset [Integer] Y offset of the source image.
     # @param source_x_size [Integer] X size (width) of the source image.
     # @param source_y_size [Integer] Y size (height) of the source image.
+    # Returns a boolean success flag; command-style public API, so renaming to
+    # a `?`-predicate would be a breaking change.
+    # rubocop:disable Naming/PredicateMethod
     def warp_region(destination_x_offset, destination_y_offset,
       destination_x_size, destination_y_size,
       source_x_offset, source_y_offset,
@@ -75,6 +80,7 @@ module GDAL
                                          source_x_size,
                                          source_y_size)
     end
+    # rubocop:enable Naming/PredicateMethod
 
     # @param destination_x_offset [Integer] X offset of the destination image.
     # @param destination_y_offset [Integer] Y offset of the destination image.
@@ -86,7 +92,9 @@ module GDAL
     # @param source_y_offset [Integer] Y offset of the source image.
     # @param source_x_size [Integer] X size (width) of the source image.
     # @param source_y_size [Integer] Y size (height) of the source image.
-    # rubocop:disable Metrics/ParameterLists
+    # PredicateMethod: returns a boolean success flag; command-style public API,
+    # renaming to a `?`-predicate would be a breaking change.
+    # rubocop:disable Metrics/ParameterLists, Naming/PredicateMethod
     def warp_region_to_buffer(destination_x_offset, destination_y_offset,
       destination_x_size, destination_y_size,
       buffer, data_type,
@@ -104,6 +112,6 @@ module GDAL
                                                  source_x_size,
                                                  source_y_size)
     end
-    # rubocop:enable Metrics/ParameterLists
+    # rubocop:enable Metrics/ParameterLists, Naming/PredicateMethod
   end
 end

--- a/lib/ogr/data_source.rb
+++ b/lib/ogr/data_source.rb
@@ -214,16 +214,23 @@ module OGR
     end
 
     # @param new_style_table [OGR::StyleTable, FFI::Pointer]
+    # @return [OGR::StyleTable] The assigned table, wrapping the pointer when
+    #   one is passed. Note: Ruby discards a setter's return value for
+    #   `data_source.style_table = x` callers.
     def style_table=(new_style_table)
       new_style_table_ptr = GDAL._pointer(OGR::StyleTable, new_style_table)
 
       FFI::OGR::API.OGR_DS_SetStyleTable(@c_pointer, new_style_table_ptr)
 
+      # Intentionally return an OGR::StyleTable (not the raw pointer); the
+      # trailing expression is a deliberate return value, not dead code.
+      # rubocop:disable Lint/Void
       if new_style_table.instance_of? OGR::StyleTable
         new_style_table
       else
         OGR::StyleTable.new(new_style_table_ptr)
       end
+      # rubocop:enable Lint/Void
     end
 
     # @param capability [String] Must be one of: ODsCCreateLayer,

--- a/lib/ogr/extensions/geometry/ewkb_record.rb
+++ b/lib/ogr/extensions/geometry/ewkb_record.rb
@@ -5,7 +5,6 @@ require "ffi-gdal"
 require "ogr"
 require_relative "wkb_record"
 
-# rubocop:disable Naming/PredicateName
 module OGR
   module Geometry
     # Parses raw EWKB and turns into a data structure. Only really exists for
@@ -57,6 +56,10 @@ module OGR
             geometry: wkb_record.geometry)
       end
 
+      # These `has_*?` predicates mirror the EWKB binary flag names (Z/M/SRID);
+      # dropping the `has_` prefix would break this public API and read less
+      # clearly against the spec, so the prefix cop is disabled here.
+      # rubocop:disable Naming/PredicatePrefix
       # @return [Boolean] Is the Z flag set?
       def has_z?
         wkb_type & WKB_Z != 0
@@ -71,6 +74,7 @@ module OGR
       def has_srid?
         wkb_type & WKB_SRID != 0
       end
+      # rubocop:enable Naming/PredicatePrefix
 
       # @return [Fixnum] Enum number that matches the FFI::OGR::Core::WKBGeometryType.
       def geometry_type
@@ -91,4 +95,3 @@ module OGR
     end
   end
 end
-# rubocop:enable Naming/PredicateName

--- a/lib/ogr/extensions/geometry/wkb_record.rb
+++ b/lib/ogr/extensions/geometry/wkb_record.rb
@@ -43,7 +43,9 @@ module OGR
       end
 
       # @return [Boolean] Is the Z flag set?
-      def has_z? # rubocop:disable Naming/PredicateName
+      # `has_z?` mirrors the WKB binary flag name; dropping the `has_` prefix
+      # would break this public API, so the prefix cop is disabled here.
+      def has_z? # rubocop:disable Naming/PredicatePrefix
         geometry_type & WKB_Z != 0
       end
 
@@ -51,7 +53,7 @@ module OGR
       #   Defined to keep the API consistent with EWKBRecord.
       def geometry_type
         # ISO SQL/MM style Z types are between 1001 and 1007
-        if wkb_type.value >= 1001 && wkb_type.value <= 1007
+        if wkb_type.value.between?(1001, 1007)
           raw_type_int = wkb_type.value - 1000
           raw_type_int | WKB_Z
         else

--- a/lib/ogr/geometries/geometry_collection_25d.rb
+++ b/lib/ogr/geometries/geometry_collection_25d.rb
@@ -8,7 +8,7 @@ module OGR
   class GeometryCollection25D < GeometryCollection
     def initialize(geometry_ptr = nil, spatial_reference: nil)
       geometry_ptr ||= OGR::Geometry.create(:wkbGeometryCollection25D)
-      super(geometry_ptr, spatial_reference: spatial_reference)
+      super
     end
   end
 end

--- a/lib/ogr/geometries/line_string_25d.rb
+++ b/lib/ogr/geometries/line_string_25d.rb
@@ -8,7 +8,7 @@ module OGR
   class LineString25D < LineString
     def initialize(geometry_ptr = nil, spatial_reference: nil)
       geometry_ptr ||= OGR::Geometry.create(:wkbLineString25D)
-      super(geometry_ptr, spatial_reference: spatial_reference)
+      super
     end
   end
 end

--- a/lib/ogr/geometries/linear_ring.rb
+++ b/lib/ogr/geometries/linear_ring.rb
@@ -8,7 +8,7 @@ module OGR
     def initialize(geometry_ptr = nil, spatial_reference: nil)
       geometry_ptr ||= OGR::Geometry.create(:wkbLinearRing)
 
-      super(geometry_ptr, spatial_reference: spatial_reference)
+      super
     end
 
     def to_line_string

--- a/lib/ogr/geometries/multi_line_string_25d.rb
+++ b/lib/ogr/geometries/multi_line_string_25d.rb
@@ -9,7 +9,7 @@ module OGR
     # @param [FFI::Pointer] geometry_ptr
     def initialize(geometry_ptr = nil, spatial_reference: nil)
       geometry_ptr ||= OGR::Geometry.create(:wkbMultiLineString25D)
-      super(geometry_ptr, spatial_reference: spatial_reference)
+      super
     end
   end
 end

--- a/lib/ogr/geometries/multi_point_25d.rb
+++ b/lib/ogr/geometries/multi_point_25d.rb
@@ -10,7 +10,7 @@ module OGR
     # @param spatial_reference [OGR::SpatialReference]
     def initialize(geometry_ptr = nil, spatial_reference: nil)
       geometry_ptr ||= OGR::Geometry.create(:wkbMultiPoint25D)
-      super(geometry_ptr, spatial_reference: spatial_reference)
+      super
     end
   end
 end

--- a/lib/ogr/geometries/multi_polygon_25d.rb
+++ b/lib/ogr/geometries/multi_polygon_25d.rb
@@ -9,7 +9,7 @@ module OGR
     # @param [FFI::Pointer] geometry_ptr
     def initialize(geometry_ptr = nil, spatial_reference: nil)
       geometry_ptr ||= OGR::Geometry.create(:wkbMultiPolygon25D)
-      super(geometry_ptr, spatial_reference: spatial_reference)
+      super
     end
   end
 end

--- a/lib/ogr/geometries/point_25d.rb
+++ b/lib/ogr/geometries/point_25d.rb
@@ -9,7 +9,7 @@ module OGR
     # @param [FFI::Pointer] geometry_ptr
     def initialize(geometry_ptr = nil, spatial_reference: nil)
       geometry_ptr ||= OGR::Geometry.create(:wkbPoint25D)
-      super(geometry_ptr, spatial_reference: spatial_reference)
+      super
     end
 
     # @return [Float]

--- a/lib/ogr/geometries/polygon_25d.rb
+++ b/lib/ogr/geometries/polygon_25d.rb
@@ -10,7 +10,7 @@ module OGR
     # @param spatial_reference [OGR::SpatialReference]
     def initialize(geometry_ptr = nil, spatial_reference: nil)
       geometry_ptr ||= OGR::Geometry.create(:wkbPolygon25D)
-      super(geometry_ptr, spatial_reference: spatial_reference)
+      super
     end
   end
 end

--- a/spec/ffi-gdal_spec.rb
+++ b/spec/ffi-gdal_spec.rb
@@ -5,19 +5,19 @@ require "ffi-gdal"
 RSpec.describe FFI do
   describe "autoload CPL" do
     it "can call CPL functions" do
-      expect { FFI::CPL }.to_not raise_exception
+      expect { FFI::CPL }.not_to raise_exception
     end
   end
 
   describe "autoload GDAL" do
     it "can call GDAL functions" do
-      expect { FFI::GDAL }.to_not raise_exception
+      expect { FFI::GDAL }.not_to raise_exception
     end
   end
 
   describe "autoload OGR" do
     it "can call OGR functions" do
-      expect { FFI::OGR }.to_not raise_exception
+      expect { FFI::OGR }.not_to raise_exception
     end
   end
 end

--- a/spec/ffi/cpl/vsi_spec.rb
+++ b/spec/ffi/cpl/vsi_spec.rb
@@ -6,42 +6,42 @@ RSpec.describe FFI::CPL::VSI do
   if GDAL.version_num >= "3060000"
     describe "VSI PathSpecificOptions" do
       around do |example|
-        FFI::CPL::VSI.VSIClearPathSpecificOptions(nil)
+        described_class.VSIClearPathSpecificOptions(nil)
         example.run
-        FFI::CPL::VSI.VSIClearPathSpecificOptions(nil)
+        described_class.VSIClearPathSpecificOptions(nil)
       end
 
       describe "VSIClearPathSpecificOptions" do
         it "properly clears credentials" do
-          FFI::CPL::VSI.VSISetPathSpecificOption("/vsis3/test", "Key1234", "Value1234")
-          expect(FFI::CPL::VSI.VSIGetPathSpecificOption("/vsis3/test", "Key1234", nil)).to eq("Value1234")
+          described_class.VSISetPathSpecificOption("/vsis3/test", "Key1234", "Value1234")
+          expect(described_class.VSIGetPathSpecificOption("/vsis3/test", "Key1234", nil)).to eq("Value1234")
 
-          FFI::CPL::VSI.VSIClearPathSpecificOptions(nil)
-          expect(FFI::CPL::VSI.VSIGetPathSpecificOption("/vsis3/test", "Key1234", nil)).to be(nil)
+          described_class.VSIClearPathSpecificOptions(nil)
+          expect(described_class.VSIGetPathSpecificOption("/vsis3/test", "Key1234", nil)).to be_nil
         end
       end
 
       describe "VSISetPathSpecificOption" do
         it "properly sets credential" do
-          expect(FFI::CPL::VSI.VSIGetPathSpecificOption("/vsis3/test", "Key1234", nil)).to be(nil)
+          expect(described_class.VSIGetPathSpecificOption("/vsis3/test", "Key1234", nil)).to be_nil
 
-          FFI::CPL::VSI.VSISetPathSpecificOption("/vsis3/test", "Key1234", "Value1234")
-          expect(FFI::CPL::VSI.VSIGetPathSpecificOption("/vsis3/test", "Key1234", nil)).to eq("Value1234")
+          described_class.VSISetPathSpecificOption("/vsis3/test", "Key1234", "Value1234")
+          expect(described_class.VSIGetPathSpecificOption("/vsis3/test", "Key1234", nil)).to eq("Value1234")
         end
       end
 
       describe "VSIGetPathSpecificOption" do
         it "properly get credential" do
-          expect(FFI::CPL::VSI.VSIGetPathSpecificOption("/vsis3/test", "Key1234", nil)).to be(nil)
+          expect(described_class.VSIGetPathSpecificOption("/vsis3/test", "Key1234", nil)).to be_nil
           expect(
-            FFI::CPL::VSI.VSIGetPathSpecificOption("/vsis3/test", "Key1234", "DefaultValue1234")
+            described_class.VSIGetPathSpecificOption("/vsis3/test", "Key1234", "DefaultValue1234")
           ).to eq("DefaultValue1234")
 
-          FFI::CPL::VSI.VSISetPathSpecificOption("/vsis3/test", "Key1234", "Value1234")
+          described_class.VSISetPathSpecificOption("/vsis3/test", "Key1234", "Value1234")
 
-          expect(FFI::CPL::VSI.VSIGetPathSpecificOption("/vsis3/test", "Key1234", nil)).to eq("Value1234")
+          expect(described_class.VSIGetPathSpecificOption("/vsis3/test", "Key1234", nil)).to eq("Value1234")
           expect(
-            FFI::CPL::VSI.VSIGetPathSpecificOption("/vsis3/test", "Key1234", "DefaultValue1234")
+            described_class.VSIGetPathSpecificOption("/vsis3/test", "Key1234", "DefaultValue1234")
           ).to eq("Value1234")
         end
       end
@@ -51,39 +51,40 @@ RSpec.describe FFI::CPL::VSI do
   if GDAL.version_num >= "3050000"
     describe "VSI Credential" do
       around do |example|
-        FFI::CPL::VSI.VSIClearCredentials(nil)
+        described_class.VSIClearCredentials(nil)
         example.run
-        FFI::CPL::VSI.VSIClearCredentials(nil)
+        described_class.VSIClearCredentials(nil)
       end
 
       describe "VSIClearCredentials" do
         it "properly clears credentials" do
-          FFI::CPL::VSI.VSISetCredential("/vsis3/test", "Key1234", "Value1234")
-          expect(FFI::CPL::VSI.VSIGetCredential("/vsis3/test", "Key1234", nil)).to eq("Value1234")
+          described_class.VSISetCredential("/vsis3/test", "Key1234", "Value1234")
+          expect(described_class.VSIGetCredential("/vsis3/test", "Key1234", nil)).to eq("Value1234")
 
-          FFI::CPL::VSI.VSIClearCredentials(nil)
-          expect(FFI::CPL::VSI.VSIGetCredential("/vsis3/test", "Key1234", nil)).to be(nil)
+          described_class.VSIClearCredentials(nil)
+          expect(described_class.VSIGetCredential("/vsis3/test", "Key1234", nil)).to be_nil
         end
       end
 
       describe "VSISetCredential" do
         it "properly sets credential" do
-          expect(FFI::CPL::VSI.VSIGetCredential("/vsis3/test", "Key1234", nil)).to be(nil)
+          expect(described_class.VSIGetCredential("/vsis3/test", "Key1234", nil)).to be_nil
 
-          FFI::CPL::VSI.VSISetCredential("/vsis3/test", "Key1234", "Value1234")
-          expect(FFI::CPL::VSI.VSIGetCredential("/vsis3/test", "Key1234", nil)).to eq("Value1234")
+          described_class.VSISetCredential("/vsis3/test", "Key1234", "Value1234")
+          expect(described_class.VSIGetCredential("/vsis3/test", "Key1234", nil)).to eq("Value1234")
         end
       end
 
       describe "VSIGetCredential" do
         it "properly get credential" do
-          expect(FFI::CPL::VSI.VSIGetCredential("/vsis3/test", "Key1234", nil)).to be(nil)
-          expect(FFI::CPL::VSI.VSIGetCredential("/vsis3/test", "Key1234", "DefaultValue1234")).to eq("DefaultValue1234")
+          expect(described_class.VSIGetCredential("/vsis3/test", "Key1234", nil)).to be_nil
+          expect(described_class.VSIGetCredential("/vsis3/test", "Key1234",
+                                                  "DefaultValue1234")).to eq("DefaultValue1234")
 
-          FFI::CPL::VSI.VSISetCredential("/vsis3/test", "Key1234", "Value1234")
+          described_class.VSISetCredential("/vsis3/test", "Key1234", "Value1234")
 
-          expect(FFI::CPL::VSI.VSIGetCredential("/vsis3/test", "Key1234", nil)).to eq("Value1234")
-          expect(FFI::CPL::VSI.VSIGetCredential("/vsis3/test", "Key1234", "DefaultValue1234")).to eq("Value1234")
+          expect(described_class.VSIGetCredential("/vsis3/test", "Key1234", nil)).to eq("Value1234")
+          expect(described_class.VSIGetCredential("/vsis3/test", "Key1234", "DefaultValue1234")).to eq("Value1234")
         end
       end
     end

--- a/spec/ffi/rttopo_spec.rb
+++ b/spec/ffi/rttopo_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe FFI::Rttopo do
   describe ".rttopo_library_path" do
     context "valid lib" do
       it "returns a String containing the path to the library" do
-        expect(described_class.rttopo_library_path).to match(/rttopo/)
+        expect(described_class.rttopo_library_path).to include("rttopo")
       end
     end
   end

--- a/spec/integration/gdal/color_table_info_spec.rb
+++ b/spec/integration/gdal/color_table_info_spec.rb
@@ -4,14 +4,15 @@ require "ffi-gdal"
 require "gdal"
 
 RSpec.describe "GDAL Color Table access", type: :integration do
-  let(:dataset) { GDAL::Dataset.open(tmp_tiff, "r") }
-  let(:tmp_tiff) { make_temp_test_file(original_tiff) }
-  after(:each) { dataset.close }
-
   subject(:color_table) do
     band = dataset.raster_band(1)
     band.color_table
   end
+
+  let(:dataset) { GDAL::Dataset.open(tmp_tiff, "r") }
+  let(:tmp_tiff) { make_temp_test_file(original_tiff) }
+
+  after { dataset.close }
 
   context "file with color table" do
     let(:original_tiff) do
@@ -21,11 +22,13 @@ RSpec.describe "GDAL Color Table access", type: :integration do
 
     describe "#palette_interpretation" do
       subject { color_table.palette_interpretation }
+
       it { is_expected.to eq :GPI_RGB }
     end
 
     describe "#color_entry_count" do
       subject { color_table.color_entry_count }
+
       it { is_expected.to eq 256 }
     end
 

--- a/spec/integration/gdal/dataset_info_spec.rb
+++ b/spec/integration/gdal/dataset_info_spec.rb
@@ -4,14 +4,14 @@ require "ffi-gdal"
 require "gdal"
 
 RSpec.describe "Dataset Info", type: :integration do
+  subject { GDAL::Dataset.open(tmp_tiff, "r") }
+
   let(:tmp_tiff) { make_temp_test_file(original_tiff) }
 
   let(:original_tiff) do
     path = "../../../spec/support/images/osgeo/geotiff/GeogToWGS84GeoKey/GeogToWGS84GeoKey5.tif"
     File.expand_path(path, __dir__)
   end
-
-  subject { GDAL::Dataset.open(tmp_tiff, "r") }
 
   after { subject.close if File.exist?(tmp_tiff) }
 
@@ -33,7 +33,7 @@ RSpec.describe "Dataset Info", type: :integration do
 
   describe "#flush_cache" do
     it "is a GDAL::Driver" do
-      expect { subject.flush_cache }.to_not raise_exception
+      expect { subject.flush_cache }.not_to raise_exception
     end
   end
 
@@ -237,7 +237,7 @@ RSpec.describe "Dataset Info", type: :integration do
 
         # Reopen dataset
         GDAL::Dataset.open(tmp_tiff, "r", shared: false) do |reopened_dataset|
-          expect(reopened_dataset.geo_transform).to_not eq(geo_transform)
+          expect(reopened_dataset.geo_transform).not_to eq(geo_transform)
         end
       end
     end
@@ -319,54 +319,55 @@ RSpec.describe "Dataset Info", type: :integration do
 
   describe "#build_overviews" do
     let(:ovr_file) { "#{tmp_tiff}.ovr" }
+
     after { FileUtils.rm_f(ovr_file) }
 
     context "nearest neighbor resampling" do
       it "creates an .ovr file with the same base name as the dataset file" do
         subject.build_overviews(:nearest, [2, 4, 8])
-        expect(File.exist?(ovr_file)).to eq true
+        expect(File.exist?(ovr_file)).to be true
       end
     end
 
     context "Gauss resampling" do
       it "creates an .ovr file with the same base name as the dataset file" do
         subject.build_overviews(:gauss, [2, 4, 8])
-        expect(File.exist?(ovr_file)).to eq true
+        expect(File.exist?(ovr_file)).to be true
       end
     end
 
     context "Cubic resampling" do
       it "creates an .ovr file with the same base name as the dataset file" do
         subject.build_overviews(:cubic, [2, 4, 8])
-        expect(File.exist?(ovr_file)).to eq true
+        expect(File.exist?(ovr_file)).to be true
       end
     end
 
     context "Average resampling" do
       it "creates an .ovr file with the same base name as the dataset file" do
         subject.build_overviews(:average, [2, 4, 8])
-        expect(File.exist?(ovr_file)).to eq true
+        expect(File.exist?(ovr_file)).to be true
       end
     end
 
     context "Mode resampling" do
       it "creates an .ovr file with the same base name as the dataset file" do
         subject.build_overviews(:mode, [2, 4, 8])
-        expect(File.exist?(ovr_file)).to eq true
+        expect(File.exist?(ovr_file)).to be true
       end
     end
 
     context "Average mag phase resampling" do
       it "creates an .ovr file with the same base name as the dataset file" do
         subject.build_overviews(:average_magphase, [2, 4, 8])
-        expect(File.exist?(ovr_file)).to eq true
+        expect(File.exist?(ovr_file)).to be true
       end
     end
 
     context "no resampling" do
       it "creates an .ovr file with the same base name as the dataset file" do
         subject.build_overviews(:none, [2, 4, 8])
-        expect(File.exist?(ovr_file)).to eq true
+        expect(File.exist?(ovr_file)).to be true
       end
     end
 
@@ -413,7 +414,7 @@ RSpec.describe "Dataset Info", type: :integration do
         expect do
           subject.raster_io("w", write_buffer, x_size: 2, y_size: 1, band_numbers: [1])
           subject.flush_cache
-        end.to_not raise_exception
+        end.not_to raise_exception
       end
     end
 

--- a/spec/integration/gdal/driver_info_spec.rb
+++ b/spec/integration/gdal/driver_info_spec.rb
@@ -7,15 +7,16 @@ RSpec.describe "Driver Info", type: :integration do
   # Without this before block, tests fail--seemingly due to too many instances
   # of the same driver open. Seems like there might be a better solution than
   # this here, but I'm not sure what it is yet.
+  subject { GDAL::Driver.by_name "GTiff" }
+
   before { FFI::GDAL::GDAL.GDALAllRegister }
+
   let(:tmp_source_tiff) { make_temp_test_file(original_source_tiff) }
 
   let(:original_source_tiff) do
     path = "../../../spec/support/images/osgeo/geotiff/GeogToWGS84GeoKey/GeogToWGS84GeoKey5.tif"
     File.expand_path(path, __dir__)
   end
-
-  subject { GDAL::Driver.by_name "GTiff" }
 
   it_behaves_like "a major object"
 
@@ -29,7 +30,7 @@ RSpec.describe "Driver Info", type: :integration do
   describe "#c_pointer" do
     it "is a FFI::Pointer to the actual C driver" do
       expect(subject.c_pointer).to be_a FFI::Pointer
-      expect(subject.c_pointer).to_not be_null
+      expect(subject.c_pointer).not_to be_null
     end
   end
 
@@ -67,7 +68,7 @@ RSpec.describe "Driver Info", type: :integration do
       end
 
       it "returns true" do
-        expect(subject.validate_creation_options(options)).to eq true
+        expect(subject.validate_creation_options(options)).to be true
       end
     end
 
@@ -77,19 +78,20 @@ RSpec.describe "Driver Info", type: :integration do
       end
 
       it "returns false" do
-        expect(subject.validate_creation_options(options)).to eq false
+        expect(subject.validate_creation_options(options)).to be false
       end
     end
   end
 
   describe "#copy_dataset_files" do
     let(:dest_tiff) { File.expand_path("copied_tiff.tif", "tmp") }
+
     after { FileUtils.rm_f(dest_tiff) }
 
     context "source is a GTiff" do
       it "copies the file" do
         subject.copy_dataset_files(tmp_source_tiff, dest_tiff)
-        expect(File.exist?(dest_tiff)).to eq true
+        expect(File.exist?(dest_tiff)).to be true
       end
     end
 
@@ -105,12 +107,13 @@ RSpec.describe "Driver Info", type: :integration do
 
   describe "#create_dataset" do
     let(:new_dataset_path) { "tmp/driver_create_dataset.tif" }
+
     after { FileUtils.rm_f(new_dataset_path) }
 
     it "creates a dataset" do
       dataset = subject.create_dataset(new_dataset_path, 2, 2)
 
-      expect(File.exist?(new_dataset_path)).to eq true
+      expect(File.exist?(new_dataset_path)).to be true
       expect(dataset).to be_a GDAL::Dataset
       expect(dataset.raster_x_size).to eq 2
       expect(dataset.raster_y_size).to eq 2
@@ -120,6 +123,7 @@ RSpec.describe "Driver Info", type: :integration do
   describe "#copy_dataset" do
     let(:copy_dataset_path) { "tmp/driver_copy_dataset.tif" }
     let(:source_dataset) { GDAL::Dataset.open(tmp_source_tiff, "r") }
+
     after { source_dataset.close }
 
     it "copies the dataset and yields a GDAL::Dataset" do
@@ -129,7 +133,7 @@ RSpec.describe "Driver Info", type: :integration do
         expect(dest_dataset.access_flag).to eq :GA_Update
       end
 
-      expect(File.exist?(copy_dataset_path)).to eq true
+      expect(File.exist?(copy_dataset_path)).to be true
     end
   end
 

--- a/spec/integration/gdal/geo_transform_info_spec.rb
+++ b/spec/integration/gdal/geo_transform_info_spec.rb
@@ -4,6 +4,8 @@ require "ffi-gdal"
 require "gdal"
 
 RSpec.describe "GeoTransform Info", type: :integration do
+  subject { dataset.geo_transform }
+
   let(:file) { make_temp_test_file(original_source_tiff) }
 
   let(:original_source_tiff) do
@@ -12,8 +14,8 @@ RSpec.describe "GeoTransform Info", type: :integration do
   end
 
   let(:dataset) { GDAL::Dataset.open(file, "r") }
+
   after { dataset.close }
-  subject { dataset.geo_transform }
 
   describe "#x_origin" do
     it "is a Float" do
@@ -24,7 +26,7 @@ RSpec.describe "GeoTransform Info", type: :integration do
   describe "#x_origin=" do
     context "param is a number" do
       it "sets the value" do
-        expect { subject.x_origin = 12.34 }.to change { subject.x_origin }
+        expect { subject.x_origin = 12.34 }.to change(subject, :x_origin)
           .from(-12.51100000000001).to(12.34)
       end
     end
@@ -45,7 +47,7 @@ RSpec.describe "GeoTransform Info", type: :integration do
   describe "#y_origin=" do
     context "param is a number" do
       it "sets the value" do
-        expect { subject.y_origin = 12.34 }.to change { subject.y_origin }
+        expect { subject.y_origin = 12.34 }.to change(subject, :y_origin)
           .from(109.03599999999999).to(12.34)
       end
     end
@@ -66,7 +68,7 @@ RSpec.describe "GeoTransform Info", type: :integration do
   describe "#pixel_width=" do
     context "param is a number" do
       it "sets the value" do
-        expect { subject.pixel_width = 12.34 }.to change { subject.pixel_width }
+        expect { subject.pixel_width = 12.34 }.to change(subject, :pixel_width)
           .from(0).to(12.34)
       end
     end
@@ -87,7 +89,7 @@ RSpec.describe "GeoTransform Info", type: :integration do
   describe "#x_rotation=" do
     context "param is a number" do
       it "sets the value" do
-        expect { subject.x_rotation = 12.34 }.to change { subject.x_rotation }
+        expect { subject.x_rotation = 12.34 }.to change(subject, :x_rotation)
           .from(0.1850509803921595).to(12.34)
       end
     end
@@ -108,7 +110,7 @@ RSpec.describe "GeoTransform Info", type: :integration do
   describe "#y_rotation=" do
     context "param is a number" do
       it "sets the value" do
-        expect { subject.y_rotation = 12.34 }.to change { subject.y_rotation }
+        expect { subject.y_rotation = 12.34 }.to change(subject, :y_rotation)
           .from(-0.3001842105263167).to(12.34)
       end
     end
@@ -129,7 +131,7 @@ RSpec.describe "GeoTransform Info", type: :integration do
   describe "#pixel_height=" do
     context "param is a number" do
       it "sets the value" do
-        expect { subject.pixel_height = 12.34 }.to change { subject.pixel_height }
+        expect { subject.pixel_height = 12.34 }.to change(subject, :pixel_height)
           .from(0.0).to(12.34)
       end
     end
@@ -209,7 +211,7 @@ RSpec.describe "GeoTransform Info", type: :integration do
       subject.to_world_file("tmp/meow", "wld")
 
       file = File.expand_path("tmp/meow.wld")
-      expect(File.exist?(file)).to eq true
+      expect(File.exist?(file)).to be true
       contents = File.readlines(file).map(&:strip)
 
       # I don't understand why the resulting world file has slightly different

--- a/spec/integration/gdal/raster_attribute_table_info_spec.rb
+++ b/spec/integration/gdal/raster_attribute_table_info_spec.rb
@@ -4,6 +4,11 @@ require "ffi-gdal"
 require "gdal"
 
 RSpec.describe "Raster Attribute Table Info", type: :integration do
+  subject do
+    band = dataset.raster_band(1)
+    band.default_raster_attribute_table
+  end
+
   let(:file) { make_temp_test_file(original_source_tiff) }
 
   let(:original_source_tiff) do
@@ -12,17 +17,13 @@ RSpec.describe "Raster Attribute Table Info", type: :integration do
   end
 
   let(:dataset) { GDAL::Dataset.open(file, "r") }
-  after { dataset.close }
 
-  subject do
-    band = dataset.raster_band(1)
-    band.default_raster_attribute_table
-  end
+  after { dataset.close }
 
   describe "#changes_written_to_file?" do
     context "no changes to file" do
       it "is true" do
-        expect(subject.changes_written_to_file?).to eq true
+        expect(subject.changes_written_to_file?).to be true
       end
     end
   end
@@ -131,7 +132,7 @@ RSpec.describe "Raster Attribute Table Info", type: :integration do
 
     context "a row does not exist for the given pixel value" do
       it "returns nil" do
-        expect(subject.row_of_value(123_456)).to eq nil
+        expect(subject.row_of_value(123_456)).to be_nil
       end
     end
   end
@@ -218,11 +219,12 @@ RSpec.describe "Raster Attribute Table Info", type: :integration do
 
   describe "#dump_readable" do
     let(:output_path) { File.expand_path("tmp/raster_attribute_table_info") }
+
     after { FileUtils.rm_f(output_path) }
 
     it "writes to the file" do
       subject.dump_readable(output_path)
-      expect(File.exist?(output_path)).to eq true
+      expect(File.exist?(output_path)).to be true
     end
   end
 end

--- a/spec/integration/gdal/raster_band_info_spec.rb
+++ b/spec/integration/gdal/raster_band_info_spec.rb
@@ -6,6 +6,8 @@ require "ffi-gdal"
 require "gdal"
 
 RSpec.describe "Raster Band Info", type: :integration do
+  subject { dataset.raster_band(1) }
+
   let(:original_tiff) do
     path = "../../../spec/support/images/osgeo/geotiff/GeogToWGS84GeoKey/GeogToWGS84GeoKey5.tif"
     File.expand_path(path, __dir__)
@@ -20,8 +22,8 @@ RSpec.describe "Raster Band Info", type: :integration do
 
   let(:tmp_tiff) { make_temp_test_file(original_tiff) }
   let(:dataset) { GDAL::Dataset.open(tmp_tiff, "w") }
+
   after { dataset.close }
-  subject { dataset.raster_band(1) }
 
   it_behaves_like "a major object"
 
@@ -84,7 +86,7 @@ RSpec.describe "Raster Band Info", type: :integration do
 
       subject.category_names.each do |category_name|
         expect(category_name).to be_a String
-        expect(category_name).to_not be_empty
+        expect(category_name).not_to be_empty
       end
     end
   end
@@ -106,7 +108,7 @@ RSpec.describe "Raster Band Info", type: :integration do
       end
 
       it "is a `false` value for :is_associated key" do
-        expect(subject.no_data_value.fetch(:is_associated)).to eq(false)
+        expect(subject.no_data_value.fetch(:is_associated)).to be(false)
       end
 
       it "has `nil` value for :value" do
@@ -131,7 +133,7 @@ RSpec.describe "Raster Band Info", type: :integration do
         expect(subject.no_data_value).to be_an Hash
 
         expect(subject.no_data_value[:value]).to be_a Float
-        expect(subject.no_data_value[:is_associated]).to_not be_nil
+        expect(subject.no_data_value[:is_associated]).not_to be_nil
       end
     end
   end
@@ -144,7 +146,7 @@ RSpec.describe "Raster Band Info", type: :integration do
 
   describe "#arbitrary_overviews?" do
     it "is true or false" do
-      expect([true, false]).to include subject.arbitrary_overviews?
+      expect(subject.arbitrary_overviews?).to be(true).or be(false)
     end
   end
 
@@ -233,8 +235,8 @@ RSpec.describe "Raster Band Info", type: :integration do
   describe "#statistics" do
     it "returns a Hash with populated values" do
       expect(subject.statistics).to be_a Hash
-      expect(%i[minimum maximum mean standard_deviation])
-        .to eq subject.statistics.keys
+      expect(subject.statistics.keys)
+        .to eq(%i[minimum maximum mean standard_deviation])
     end
 
     it "has a :minimum that ranges between 0.0/-32768.0 and 255.0" do
@@ -378,7 +380,7 @@ RSpec.describe "Raster Band Info", type: :integration do
       if histogram
         expect(histogram[:totals]).to be_an Array
         expect(histogram[:totals].size).to eq(256).or eq(0)
-        expect(histogram[:totals].all? { |t| t.instance_of?(Integer) }).to eq true
+        expect(histogram[:totals].all?(Integer)).to be true
       end
     end
   end
@@ -407,7 +409,7 @@ RSpec.describe "Raster Band Info", type: :integration do
   describe "#minimum_value" do
     it "returns a Hash with populated values" do
       expect(subject.minimum_value).to be_a Hash
-      expect(%i[value is_tight]).to eq subject.minimum_value.keys
+      expect(subject.minimum_value.keys).to eq(%i[value is_tight])
     end
 
     it "has a :value that is a Float" do
@@ -415,14 +417,14 @@ RSpec.describe "Raster Band Info", type: :integration do
     end
 
     it "has a :is_tight that is nil (since the examples are geotiffs)" do
-      # expect(subject.minimum_value[:is_tight]).to eq nil
+      skip "assertion on :is_tight not yet implemented for the geotiff fixtures"
     end
   end
 
   describe "#maximum_value" do
     it "returns a Hash with populated values" do
       expect(subject.maximum_value).to be_a Hash
-      expect(%i[value is_tight]).to eq subject.maximum_value.keys
+      expect(subject.maximum_value.keys).to eq(%i[value is_tight])
     end
 
     it "has a :value that is a Float" do
@@ -430,7 +432,7 @@ RSpec.describe "Raster Band Info", type: :integration do
     end
 
     it "has a :is_tight that is nil (since the examples are geotiffs)" do
-      # expect(subject.maximum_value[:is_tight]).to eq nil
+      skip "assertion on :is_tight not yet implemented for the geotiff fixtures"
     end
   end
 end

--- a/spec/integration/ogr/layer/extensions_spec.rb
+++ b/spec/integration/ogr/layer/extensions_spec.rb
@@ -3,6 +3,10 @@
 require "ogr/extensions/layer/extensions"
 
 RSpec.describe "OGR::Layer::Extensions" do
+  subject do
+    layer0
+  end
+
   let(:data_source) do
     OGR::DataSource.open("spec/support/shapefiles/states_21basic/states.shp", "r")
   end
@@ -11,12 +15,9 @@ RSpec.describe "OGR::Layer::Extensions" do
     data_source.layer(0)
   end
 
-  subject do
-    layer0
-  end
-
   describe "#features" do
     subject { layer0.features }
+
     it { is_expected.to be_an Array }
     specify { expect(subject.first).to be_a OGR::Feature }
     specify { expect(subject.size).to eq layer0.feature_count }

--- a/spec/integration/ogr/layer_spec.rb
+++ b/spec/integration/ogr/layer_spec.rb
@@ -3,6 +3,10 @@
 require "ogr"
 
 RSpec.describe "OGR::Layer" do
+  subject do
+    layer0
+  end
+
   let(:data_source) do
     OGR::DataSource.open("spec/support/shapefiles/states_21basic/states.shp", "r")
   end
@@ -11,70 +15,79 @@ RSpec.describe "OGR::Layer" do
     data_source.layer(0)
   end
 
-  subject do
-    layer0
-  end
-
   describe "#name" do
     subject { layer0.name }
+
     it { is_expected.to eq "states" }
   end
 
   describe "#geometry_type" do
     subject { layer0.geometry_type }
+
     it { is_expected.to eq :wkbPolygon }
   end
 
   describe "#feature_count" do
     subject { layer0.feature_count }
+
     it { is_expected.to eq 51 }
   end
 
   describe "#feature" do
     subject { layer0.feature(0) }
+
     it { is_expected.to be_a OGR::Feature }
   end
 
   describe "#next_feature" do
     subject { layer0.next_feature }
+
     after { subject.destroy! }
+
     it { is_expected.to be_a OGR::Feature }
   end
 
   describe "#features_read" do
     subject { layer0.features_read }
+
     it { is_expected.to be >= 0 }
   end
 
   describe "#feature_definition" do
     subject { layer0.feature_definition }
+
     it { is_expected.to be_a OGR::FeatureDefinition }
   end
 
   describe "#spatial_reference" do
     subject { layer0.spatial_reference }
+
     it { is_expected.to be_a OGR::SpatialReference }
   end
 
   describe "#extent" do
     subject { layer0.extent }
+
     it { is_expected.to be_a OGR::Envelope }
   end
 
   describe "#fid_column" do
     subject { layer0.fid_column }
+
     it { is_expected.to be_a String }
     it { is_expected.to be_empty }
   end
 
   describe "#geometry_column" do
     subject { layer0.geometry_column }
+
     it { is_expected.to be_a String }
     it { is_expected.to be_empty }
   end
 
   describe "#style_table" do
     subject { layer0.style_table }
+
     it { is_expected.to be_nil }
   end
 end

--- a/spec/support/shared_contexts.rb
+++ b/spec/support/shared_contexts.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.shared_context "A .tif Dataset" do
-  let(:file_path) do
-    File.expand_path("images/osgeo/geotiff/GeogToWGS84GeoKey/GeogToWGS84GeoKey5.tif", __dir__)
-  end
-
   subject do
     GDAL::Dataset.open(file_path, "r", shared: false)
+  end
+
+  let(:file_path) do
+    File.expand_path("images/osgeo/geotiff/GeogToWGS84GeoKey/GeogToWGS84GeoKey5.tif", __dir__)
   end
 end
 
@@ -14,25 +14,25 @@ RSpec.shared_context "OGR::Layer, spatial_reference" do
   require "ogr/driver"
   require "ogr/spatial_reference"
 
-  let(:driver) { OGR::Driver.by_name "Memory" }
-  let(:data_source) { driver.create_data_source "spec data source" }
-
   subject(:layer) do
     data_source.create_layer "spec layer",
                              geometry_type: :wkbMultiPoint,
                              spatial_reference: OGR::SpatialReference.new.import_from_epsg(4326)
   end
+
+  let(:driver) { OGR::Driver.by_name "Memory" }
+  let(:data_source) { driver.create_data_source "spec data source" }
 end
 
 RSpec.shared_context "OGR::Layer, no spatial_reference" do
   require "ogr/driver"
   require "ogr/spatial_reference"
 
-  let(:driver) { OGR::Driver.by_name "Memory" }
-  let(:data_source) { driver.create_data_source "spec data source" }
-
   subject(:layer) do
     data_source.create_layer "spec layer",
                              geometry_type: :wkbMultiPoint
   end
+
+  let(:driver) { OGR::Driver.by_name "Memory" }
+  let(:data_source) { driver.create_data_source "spec data source" }
 end

--- a/spec/support/shared_examples/gdal/major_object_examples.rb
+++ b/spec/support/shared_examples/gdal/major_object_examples.rb
@@ -5,9 +5,7 @@ RSpec.shared_examples "a major object" do
     it "is an Array of Strings" do
       expect(subject.metadata_domain_list).to be_an Array
 
-      subject.metadata_domain_list.each do |mdl|
-        expect(mdl).to be_a String
-      end
+      expect(subject.metadata_domain_list).to all(be_a String)
     end
   end
 
@@ -50,6 +48,6 @@ RSpec.shared_examples "a major object" do
   end
 
   describe "#null?" do
-    it { is_expected.to_not be_null }
+    it { is_expected.not_to be_null }
   end
 end

--- a/spec/support/shared_examples/ogr/a_geometry.rb
+++ b/spec/support/shared_examples/ogr/a_geometry.rb
@@ -5,6 +5,7 @@ RSpec.shared_examples "a geometry" do
 
   describe "#coordinate_dimension" do
     subject { geometry.coordinate_dimension }
+
     it { is_expected.to eq 2 }
   end
 
@@ -31,6 +32,7 @@ RSpec.shared_examples "a geometry" do
   describe "#empty?" do
     context "when empty" do
       subject { described_class.new }
+
       it { is_expected.to be_empty }
     end
 
@@ -43,6 +45,7 @@ RSpec.shared_examples "a geometry" do
 
   describe "#envelope" do
     subject { geometry.envelope }
+
     it { is_expected.to be_a OGR::Envelope }
   end
 
@@ -294,6 +297,9 @@ RSpec.shared_examples "a geometry" do
   end
 
   describe "#transform_to!" do
+    # Two distinct pending specs; their `skip` bodies coincide, which trips
+    # RSpec/RepeatedExample even though the intended behaviors differ.
+    # rubocop:disable RSpec/RepeatedExample
     it "transforms the points into the new spatial reference" do
       skip
     end
@@ -301,6 +307,7 @@ RSpec.shared_examples "a geometry" do
     it "sets the new spatial reference" do
       skip
     end
+    # rubocop:enable RSpec/RepeatedExample
   end
 
   describe "#simplify" do
@@ -371,7 +378,7 @@ RSpec.shared_examples "a geometry" do
         expect { geometry.to_wkb }.to raise_exception OGR::UnsupportedOperation
       else
         expect(geometry.to_wkb).to be_a String
-        expect(geometry.to_wkb).to_not be_empty
+        expect(geometry.to_wkb).not_to be_empty
       end
     end
   end
@@ -379,28 +386,28 @@ RSpec.shared_examples "a geometry" do
   describe "#to_wkt" do
     it "returns some String data" do
       expect(geometry.to_wkt).to be_a String
-      expect(geometry.to_wkt).to_not be_empty
+      expect(geometry.to_wkt).not_to be_empty
     end
   end
 
   describe "#to_gml" do
     it "returns some String data" do
       expect(geometry.to_gml).to be_a String
-      expect(geometry.to_gml).to_not be_empty
+      expect(geometry.to_gml).not_to be_empty
     end
   end
 
   describe "#to_kml" do
     it "returns some String data" do
       expect(geometry.to_kml).to be_a String
-      expect(geometry.to_kml).to_not be_empty
+      expect(geometry.to_kml).not_to be_empty
     end
   end
 
   describe "#to_geo_json" do
     it "returns some String data" do
       expect(geometry.to_geo_json).to be_a String
-      expect(geometry.to_geo_json).to_not be_empty
+      expect(geometry.to_geo_json).not_to be_empty
     end
   end
 end

--- a/spec/support/shared_examples/ogr/a_line_string.rb
+++ b/spec/support/shared_examples/ogr/a_line_string.rb
@@ -3,16 +3,19 @@
 RSpec.shared_examples "a line string" do
   describe "#dimension" do
     subject { geometry.dimension }
+
     it { is_expected.to eq 1 }
   end
 
   describe "#type" do
     subject { geometry.type }
+
     it { is_expected.to eq :wkbLineString }
   end
 
   describe "#type_to_name" do
     subject { geometry.type }
+
     it { is_expected.to eq :wkbLineString }
   end
 end

--- a/spec/unit/ext/numeric_as_data_type_spec.rb
+++ b/spec/unit/ext/numeric_as_data_type_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Numeric do
     context "integer data types" do
       it "returns an Integer" do
         integer_data_types.each do |data_type|
-          expect(subject.to_data_type(data_type)).to eql 1
+          expect(subject.to_data_type(data_type)).to be 1
           expect(subject.to_data_type(data_type)).to be_an Integer
         end
       end
@@ -26,7 +26,7 @@ RSpec.describe Numeric do
     context "float data types" do
       it "returns a Float" do
         float_data_types.each do |data_type|
-          expect(subject.to_data_type(data_type)).to eql 1.0
+          expect(subject.to_data_type(data_type)).to be 1.0
           expect(subject.to_data_type(data_type)).to be_a Float
         end
       end
@@ -49,7 +49,7 @@ RSpec.describe Numeric do
 
     context "unknown data type" do
       it "returns self" do
-        expect(subject.to_data_type("meow")).to eql 1
+        expect(subject.to_data_type("meow")).to be 1
         expect(subject.to_data_type("meow")).to be_a Integer
       end
     end
@@ -75,7 +75,7 @@ RSpec.describe Numeric do
       context "integer data types" do
         it "returns an Integer" do
           integer_data_types.each do |data_type|
-            expect(subject.to_data_type(data_type)).to eql 1
+            expect(subject.to_data_type(data_type)).to be 1
             expect(subject.to_data_type(data_type)).to be_an Integer
           end
         end
@@ -103,7 +103,7 @@ RSpec.describe Numeric do
       context "integer data types" do
         it "returns an Integer" do
           integer_data_types.each do |data_type|
-            expect(subject.to_data_type(data_type)).to eql 1
+            expect(subject.to_data_type(data_type)).to be 1
             expect(subject.to_data_type(data_type)).to be_an Integer
           end
         end

--- a/spec/unit/ffi/gdal_spec.rb
+++ b/spec/unit/ffi/gdal_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe FFI::GDAL do
   describe "._files_with_constants" do
     it "returns a non-empty Array" do
       expect(described_class._files_with_constants).to be_an Array
-      expect(described_class._files_with_constants).to_not be_empty
+      expect(described_class._files_with_constants).not_to be_empty
     end
   end
 

--- a/spec/unit/gdal/color_interpretation_spec.rb
+++ b/spec/unit/gdal/color_interpretation_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe GDAL::ColorInterpretation do
   describe ".name" do
     context "valid value" do
       it "returns an object" do
-        expect(GDAL::ColorInterpretation.name(:GCI_BlueBand)).to eq "Blue"
+        expect(described_class.name(:GCI_BlueBand)).to eq "Blue"
       end
     end
   end
@@ -14,7 +14,7 @@ RSpec.describe GDAL::ColorInterpretation do
   describe ".by_name" do
     context "valid name" do
       it "returns an object" do
-        expect(GDAL::ColorInterpretation.by_name("Blue")).to eq :GCI_BlueBand
+        expect(described_class.by_name("Blue")).to eq :GCI_BlueBand
       end
     end
   end

--- a/spec/unit/gdal/color_table_spec.rb
+++ b/spec/unit/gdal/color_table_spec.rb
@@ -3,6 +3,10 @@
 require "gdal/color_table"
 
 RSpec.describe GDAL::ColorTable do
+  subject do
+    described_class.new(:GPI_RGB)
+  end
+
   describe "#initialize" do
     context "with a valid PaletteInterpretation" do
       it "creates a new ColorTable" do
@@ -49,10 +53,6 @@ RSpec.describe GDAL::ColorTable do
         described_class.new(:GPI_HLS)
       end
     end
-  end
-
-  subject do
-    described_class.new(:GPI_RGB)
   end
 
   describe "#palette_interpretation" do

--- a/spec/unit/gdal/data_type_spec.rb
+++ b/spec/unit/gdal/data_type_spec.rb
@@ -22,13 +22,13 @@ RSpec.describe GDAL::DataType do
   describe ".complex?" do
     context "with valid, complex data type" do
       it "returns true" do
-        expect(described_class.complex?(:GDT_CFloat64)).to eq true
+        expect(described_class.complex?(:GDT_CFloat64)).to be true
       end
     end
 
     context "with valid, simple data type" do
       it "returns true" do
-        expect(described_class.complex?(:GDT_Float64)).to eq false
+        expect(described_class.complex?(:GDT_Float64)).to be false
       end
     end
 

--- a/spec/unit/gdal/dataset/class_methods_spec.rb
+++ b/spec/unit/gdal/dataset/class_methods_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe GDAL::Dataset do
     end
 
     context "block given" do
-      let(:dataset) { instance_double "GDAL::Dataset" }
+      let(:dataset) { instance_double described_class }
 
       it "yields then closes the opened DataSource" do
         allow(described_class).to receive(:new).and_return dataset
@@ -33,7 +33,7 @@ RSpec.describe GDAL::Dataset do
                     .by_name("MEM")
                     .create_dataset("testy", subject.raster_x_size, subject.raster_y_size,
                                     band_count: subject.raster_count, data_type: subject.raster_band(1).data_type)
-      described_class.copy_whole_raster(subject, destination)
+      expect { described_class.copy_whole_raster(subject, destination) }.not_to raise_error
     end
   end
 end

--- a/spec/unit/gdal/dataset/warp_methods_spec.rb
+++ b/spec/unit/gdal/dataset/warp_methods_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe GDAL::Dataset do
       subject.reproject_image(dest_dataset, :GRA_CubicSpline)
 
       dest_dataset.flush_cache
-      expect(dest_dataset.projection).to match(/AUTHORITY\["EPSG","3857"\]/)
+      expect(dest_dataset.projection).to include('AUTHORITY["EPSG","3857"]')
       expect(dest_dataset.raster_count).to eq(subject.raster_count)
     end
   end
@@ -40,8 +40,8 @@ RSpec.describe GDAL::Dataset do
                                          OGR::SpatialReference.new.import_from_epsg(3857).to_wkt,
                                          GDAL::Driver.by_name("GTiff"))
 
-      dest_dataset = GDAL::Dataset.open(output_file, "r")
-      expect(dest_dataset.projection).to match(/AUTHORITY\["EPSG","3857"\]/)
+      dest_dataset = described_class.open(output_file, "r")
+      expect(dest_dataset.projection).to include('AUTHORITY["EPSG","3857"]')
       expect(dest_dataset.raster_count).to eq(subject.raster_count)
 
       dest_driver = dest_dataset.driver

--- a/spec/unit/gdal/driver_spec.rb
+++ b/spec/unit/gdal/driver_spec.rb
@@ -5,6 +5,7 @@ require "gdal/driver"
 RSpec.describe GDAL::Driver do
   describe ".count" do
     subject { described_class.count }
+
     it { is_expected.to be_positive }
   end
 
@@ -18,7 +19,8 @@ RSpec.describe GDAL::Driver do
 
     context "valid driver name" do
       subject { described_class.by_name("MEM") }
-      it { is_expected.to be_an_instance_of GDAL::Driver }
+
+      it { is_expected.to be_an_instance_of described_class }
     end
   end
 
@@ -32,19 +34,22 @@ RSpec.describe GDAL::Driver do
 
     context "valid index" do
       subject { described_class.at_index(0) }
-      it { is_expected.to be_an_instance_of GDAL::Driver }
+
+      it { is_expected.to be_an_instance_of described_class }
     end
   end
 
   describe ".identify_driver" do
     context "file is not supported" do
       subject { described_class.identify_driver(__FILE__) }
+
       it { is_expected.to be_nil }
     end
 
     context "file is supported" do
       subject { described_class.identify_driver("spec/support/worldfiles/SR_50M/SR_50M.tif") }
-      it { is_expected.to be_an_instance_of GDAL::Driver }
+
+      it { is_expected.to be_an_instance_of described_class }
     end
   end
 end

--- a/spec/unit/gdal/environment_methods_spec.rb
+++ b/spec/unit/gdal/environment_methods_spec.rb
@@ -4,4 +4,8 @@ require "gdal/environment_methods"
 
 RSpec.describe GDAL::EnvironmentMethods do
   subject { Object.new.extend(described_class) }
+
+  it "is extendable onto an object" do
+    expect(subject).to be_a(described_class)
+  end
 end

--- a/spec/unit/gdal/extensions/geo_transform/extensions_spec.rb
+++ b/spec/unit/gdal/extensions/geo_transform/extensions_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe GDAL::GeoTransform::Extensions do
   end
 
   describe ".new_from_envelope" do
-    let(:envelope) { instance_double "OGR::Envelope" }
+    let(:envelope) { instance_double OGR::Envelope }
 
     it "builds a new GeoTransform using the extent values from the Envelope" do
       expect(envelope).to receive(:x_min).and_return(90)

--- a/spec/unit/gdal/extensions/gridder/point_extracting_spec.rb
+++ b/spec/unit/gdal/extensions/gridder/point_extracting_spec.rb
@@ -3,14 +3,14 @@
 require "gdal/extensions/gridder"
 
 RSpec.describe GDAL::Gridder do
-  let(:source_layer) { instance_double "OGR::Layer" }
-  let(:dest_file_name) { "blah.docx" }
-  let(:gridder_options) { instance_double "GDAL::GridderOptions" }
-
   subject(:gridder) { described_class.new(source_layer, dest_file_name, gridder_options) }
 
+  let(:source_layer) { instance_double OGR::Layer }
+  let(:dest_file_name) { "blah.docx" }
+  let(:gridder_options) { instance_double GDAL::GridderOptions }
+
   describe "#points" do
-    let(:clipping_geometry) { instance_double "OGR::LineString" }
+    let(:clipping_geometry) { instance_double OGR::LineString }
 
     before do
       expect(subject).to receive(:ensure_z_values)
@@ -70,8 +70,7 @@ RSpec.describe GDAL::Gridder do
       before do
         allow(subject).to receive(:layer_missing_specified_field?).and_return false
         allow(gridder_options).to receive(:input_field_name).and_return nil
-        allow(source_layer).to receive(:any_geometries_with_z?).and_return false
-        allow(source_layer).to receive(:name).and_return "meow"
+        allow(source_layer).to receive_messages(any_geometries_with_z?: false, name: "meow")
       end
 
       it "raises an GDAL::NoValuesToGrid" do
@@ -85,6 +84,7 @@ RSpec.describe GDAL::Gridder do
 
     context "input_field_name not set" do
       before { allow(gridder_options).to receive(:input_field_name).and_return nil }
+
       it { is_expected.to be false }
     end
 

--- a/spec/unit/gdal/extensions/gridder_options_spec.rb
+++ b/spec/unit/gdal/extensions/gridder_options_spec.rb
@@ -35,16 +35,19 @@ RSpec.describe GDAL::GridderOptions do
   describe "default values" do
     describe "#output_data_type" do
       subject { gridder_options.output_data_type }
+
       it { is_expected.to eq :GDT_Float64 }
     end
 
     describe "#output_format" do
       subject { gridder_options.output_format }
+
       it { is_expected.to eq "GTiff" }
     end
 
     describe "#output_size" do
       subject { gridder_options.output_size }
+
       it { is_expected.to eq(width: 256, height: 256) }
     end
   end

--- a/spec/unit/gdal/extensions/gridder_spec.rb
+++ b/spec/unit/gdal/extensions/gridder_spec.rb
@@ -3,14 +3,14 @@
 require "gdal/extensions/gridder"
 
 RSpec.describe GDAL::Gridder do
-  let(:source_layer) { instance_double "OGR::Layer" }
-  let(:dest_file_name) { "blah.docx" }
-  let(:gridder_options) { instance_double "GDAL::GridderOptions" }
-
   subject(:gridder) { described_class.new(source_layer, dest_file_name, gridder_options) }
 
+  let(:source_layer) { instance_double OGR::Layer }
+  let(:dest_file_name) { "blah.docx" }
+  let(:gridder_options) { instance_double GDAL::GridderOptions }
+
   describe "#build_output_spatial_reference" do
-    let(:spatial_reference) { instance_double "OGR::SpatialRefernce" }
+    let(:spatial_reference) { instance_double OGR::SpatialReference }
 
     context "no output_projection given, source layer has one set" do
       before do
@@ -42,7 +42,7 @@ RSpec.describe GDAL::Gridder do
       end
 
       it "returns nil" do
-        expect(subject.send(:build_output_spatial_reference)).to eq nil
+        expect(subject.send(:build_output_spatial_reference)).to be_nil
       end
     end
   end
@@ -57,7 +57,7 @@ RSpec.describe GDAL::Gridder do
     end
 
     context "output_x_extent is not set" do
-      let(:extent) { instance_double "OGR::Envelope", x_min: 456 }
+      let(:extent) { instance_double OGR::Envelope, x_min: 456 }
 
       before do
         allow(gridder_options).to receive(:output_x_extent).and_return({})
@@ -80,7 +80,7 @@ RSpec.describe GDAL::Gridder do
     end
 
     context "output_x_extent is not set" do
-      let(:extent) { instance_double "OGR::Envelope", x_max: 654 }
+      let(:extent) { instance_double OGR::Envelope, x_max: 654 }
 
       before do
         allow(gridder_options).to receive(:output_x_extent).and_return({})
@@ -103,7 +103,7 @@ RSpec.describe GDAL::Gridder do
     end
 
     context "output_y_extent is not set" do
-      let(:extent) { instance_double "OGR::Envelope", y_min: 456 }
+      let(:extent) { instance_double OGR::Envelope, y_min: 456 }
 
       before do
         allow(gridder_options).to receive(:output_y_extent).and_return({})
@@ -126,7 +126,7 @@ RSpec.describe GDAL::Gridder do
     end
 
     context "output_y_extent is not set" do
-      let(:extent) { instance_double "OGR::Envelope", y_max: 654 }
+      let(:extent) { instance_double OGR::Envelope, y_max: 654 }
 
       before do
         allow(gridder_options).to receive(:output_y_extent).and_return({})

--- a/spec/unit/gdal/extensions/raster_band/extensions_spec.rb
+++ b/spec/unit/gdal/extensions/raster_band/extensions_spec.rb
@@ -4,68 +4,81 @@ require "gdal/driver"
 require "gdal/extensions/raster_band/extensions"
 
 RSpec.describe "GDAL::RasterBand::Extensions" do
+  subject(:raster_band) { dataset_byte.raster_band(1) }
+
   let(:driver) { GDAL::Driver.by_name("MEM") }
   let(:dataset_byte) { driver.create_dataset("test", 15, 25, data_type: :GDT_Byte) }
-  subject(:raster_band) { dataset_byte.raster_band(1) }
 
   describe "#to_a" do
     subject { raster_band.to_a }
+
     it { is_expected.to eq(Array.new(25, Array.new(15, 0))) }
   end
 
   describe "#to_na" do
     context "no conversion" do
       subject { raster_band.to_na }
+
       it { is_expected.to eq(NArray.byte(15, 25)) }
     end
 
     context "convert to Int16" do
       subject { raster_band.to_na(:GDT_Int16) }
+
       it { is_expected.to eq(NArray.sint(15, 25)) }
     end
 
     context "convert to UInt16" do
       subject { raster_band.to_na(:GDT_UInt16) }
+
       it { is_expected.to eq(NArray.int(15, 25)) }
     end
 
     context "convert to Int32" do
       subject { raster_band.to_na(:GDT_Int32) }
+
       it { is_expected.to eq(NArray.int(15, 25)) }
     end
 
     context "convert to UInt32" do
       subject { raster_band.to_na(:GDT_UInt32) }
+
       it { is_expected.to eq(NArray.int(15, 25)) }
     end
 
     context "convert to Float32" do
       subject { raster_band.to_na(:GDT_Float32) }
+
       it { is_expected.to eq(NArray.sfloat(15, 25)) }
     end
 
     context "convert to Float64" do
       subject { raster_band.to_na(:GDT_Float64) }
+
       it { is_expected.to eq(NArray.float(15, 25)) }
     end
 
     context "convert to CInt16" do
       subject { raster_band.to_na(:GDT_CInt16) }
+
       it { is_expected.to eq(NArray.scomplex(15, 25)) }
     end
 
     context "convert to CInt32" do
       subject { raster_band.to_na(:GDT_CInt32) }
+
       it { is_expected.to eq(NArray.scomplex(15, 25)) }
     end
 
     context "convert to CFloat32" do
       subject { raster_band.to_na(:GDT_CFloat32) }
+
       it { is_expected.to eq(NArray.scomplex(15, 25)) }
     end
 
     context "convert to CFloat64" do
       subject { raster_band.to_na(:GDT_CFloat64) }
+
       it { is_expected.to eq(NArray.complex(15, 25)) }
     end
   end

--- a/spec/unit/gdal/extensions/raster_band/io_extensions_spec.rb
+++ b/spec/unit/gdal/extensions/raster_band/io_extensions_spec.rb
@@ -4,6 +4,8 @@ require "gdal/driver"
 require "gdal/extensions/raster_band/extensions"
 
 RSpec.describe "GDAL::RasterBand::IOExtensions" do
+  subject(:raster_band) { dataset_byte.raster_band(1) }
+
   let(:driver) { GDAL::Driver.by_name("MEM") }
   let(:dataset_byte) { driver.create_dataset("test", 15, 25, data_type: :GDT_Byte) }
   let(:dataset_int8) { driver.create_dataset("test", 15, 25, data_type: :GDT_Int8) }
@@ -15,8 +17,6 @@ RSpec.describe "GDAL::RasterBand::IOExtensions" do
   let(:dataset_int64) { driver.create_dataset("test", 15, 25, data_type: :GDT_Int64) }
   let(:dataset_float32) { driver.create_dataset("test", 15, 25, data_type: :GDT_Float32) }
   let(:dataset_float64) { driver.create_dataset("test", 15, 25, data_type: :GDT_Float64) }
-
-  subject(:raster_band) { dataset_byte.raster_band(1) }
 
   describe "#write_xy_narray" do
     let(:dataset) { driver.create_dataset("test dataset", 64, 4) }
@@ -152,11 +152,14 @@ RSpec.describe "GDAL::RasterBand::IOExtensions" do
 
   describe "#block_buffer_size" do
     subject { raster_band.block_buffer_size }
+
     it { is_expected.to eq(15) }
   end
 
   describe "#read_lines_by_block" do
     context "block size is larger than the raster" do
+      subject { dataset.raster_band(1) }
+
       let(:rows) { (1..4).map { |i| Array.new(15) { i } } }
 
       let(:dataset_path) do
@@ -167,12 +170,9 @@ RSpec.describe "GDAL::RasterBand::IOExtensions" do
         end
         filename
       end
-
-      after { FileUtils.rm_f(dataset_path) }
-
       let(:dataset) { GDAL::Dataset.open(dataset_path, "r") }
 
-      subject { dataset.raster_band(1) }
+      after { FileUtils.rm_f(dataset_path) }
 
       it "yields all block rows with correct values" do
         expect { |b| subject.read_lines_by_block(&b) }

--- a/spec/unit/gdal/extensions/raster_band_classifier_spec.rb
+++ b/spec/unit/gdal/extensions/raster_band_classifier_spec.rb
@@ -5,6 +5,8 @@ require "gdal/extensions/raster_band_classifier"
 require "gdal/extensions/raster_band/extensions"
 
 RSpec.describe GDAL::RasterBandClassifier do
+  subject(:classifier) { described_class.new(raster_band) }
+
   let(:driver) { GDAL::Driver.by_name("MEM") }
 
   let(:dataset) do
@@ -17,7 +19,6 @@ RSpec.describe GDAL::RasterBandClassifier do
   end
 
   let(:raster_band) { dataset.raster_band 1 }
-  subject(:classifier) { described_class.new(raster_band) }
 
   describe "#add_range" do
     context "range param is a Range" do
@@ -68,6 +69,8 @@ RSpec.describe GDAL::RasterBandClassifier do
     end
 
     context "band type is :GDT_Float32" do
+      subject { classifier.equal_count_ranges(4) }
+
       let(:raster_band) do
         band = float_dataset.raster_band 1
         new_values = band.to_na.indgen!
@@ -78,8 +81,6 @@ RSpec.describe GDAL::RasterBandClassifier do
       let(:float_dataset) do
         driver.create_dataset "test dataset", 640, 480, data_type: :GDT_Float32
       end
-
-      subject { classifier.equal_count_ranges(4) }
 
       it "is an Array of Hashes" do
         expect(subject).to be_an Array
@@ -94,11 +95,13 @@ RSpec.describe GDAL::RasterBandClassifier do
 
     context "not enough values between breaks to generate unique break values" do
       subject { classifier.equal_count_ranges(1_000) }
+
       it { is_expected.to be_nil }
     end
 
     context "all same value" do
       let(:band_narray) { Numo::Int8.new(3, 5).fill(1) }
+
       before { allow(raster_band).to receive(:to_nna).and_return(band_narray) }
 
       it "returns a single range when 1 is requested" do
@@ -108,6 +111,7 @@ RSpec.describe GDAL::RasterBandClassifier do
 
     context "all nodata pixels" do
       let(:band_narray) { Numo::Int8.new(3, 5).fill(0) }
+
       before { allow(raster_band).to receive(:to_nna).and_return(band_narray) }
 
       it "returns an empty Array" do
@@ -156,7 +160,7 @@ RSpec.describe GDAL::RasterBandClassifier do
       end
 
       it "retains its NODATA pixels" do
-        expect { subject.classify! }.to_not(change { raster_band.to_na.eq(-9999.0).count_true })
+        expect { subject.classify! }.not_to(change { raster_band.to_na.eq(-9999.0).count_true })
       end
     end
 
@@ -186,7 +190,7 @@ RSpec.describe GDAL::RasterBandClassifier do
       end
 
       it "retains its NODATA pixels" do
-        expect { subject.classify! }.to_not(change { raster_band.to_na.eq(-9999.0).count_true })
+        expect { subject.classify! }.not_to(change { raster_band.to_na.eq(-9999.0).count_true })
         pixels = raster_band.to_na
         expect(pixels.eq(-9999).count_true).to eq 640
         expect(pixels.eq(0).count_true).to eq 0
@@ -217,7 +221,7 @@ RSpec.describe GDAL::RasterBandClassifier do
       end
 
       it "retains its NODATA pixels" do
-        expect { subject.classify! }.to_not(change { raster_band.to_na.eq(-9999.0).count_true })
+        expect { subject.classify! }.not_to(change { raster_band.to_na.eq(-9999.0).count_true })
       end
     end
   end

--- a/spec/unit/gdal/geo_transform_spec.rb
+++ b/spec/unit/gdal/geo_transform_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe GDAL::GeoTransform do
     context "a valid file" do
       it "reads in the file" do
         result = described_class.from_world_file(world_file_path)
-        expect(result).to be_a GDAL::GeoTransform
+        expect(result).to be_a described_class
       end
     end
 
@@ -31,31 +31,37 @@ RSpec.describe GDAL::GeoTransform do
 
     describe "#x_origin" do
       subject { world.x_origin }
+
       it { is_expected.to eq(-179.99999999999997) }
     end
 
     describe "#pixel_width" do
       subject { world.pixel_width }
+
       it { is_expected.to eq 0.03333333333333 }
     end
 
     describe "#x_rotation" do
       subject { world.x_rotation }
+
       it { is_expected.to eq 0.0 }
     end
 
     describe "#y_origin" do
       subject { world.y_origin }
+
       it { is_expected.to eq 90.0 }
     end
 
     describe "#pixel_height" do
       subject { world.pixel_height }
+
       it { is_expected.to eq(-0.03333333333333) }
     end
 
     describe "#y_rotation" do
       subject { world.y_rotation }
+
       it { is_expected.to eq 0.0 }
     end
   end
@@ -145,17 +151,6 @@ RSpec.describe GDAL::GeoTransform do
       end
 
       context "given parameter is a GeoTransform" do
-        let(:other_geo_transform) do
-          gt = described_class.new
-          gt.x_origin = 1000
-          gt.y_origin = 1000
-          gt.pixel_width = 0.5
-          gt.pixel_height = 0.25
-          gt.x_rotation = 1.0
-          gt.y_rotation = -1.0
-          gt
-        end
-
         subject do
           gt = described_class.new
           gt.x_origin = 500
@@ -168,8 +163,19 @@ RSpec.describe GDAL::GeoTransform do
           gt.compose(other_geo_transform)
         end
 
+        let(:other_geo_transform) do
+          gt = described_class.new
+          gt.x_origin = 1000
+          gt.y_origin = 1000
+          gt.pixel_width = 0.5
+          gt.pixel_height = 0.25
+          gt.x_rotation = 1.0
+          gt.y_rotation = -1.0
+          gt
+        end
+
         it "is a new GeoTransform" do
-          expect(subject).to be_a GDAL::GeoTransform
+          expect(subject).to be_a described_class
         end
 
         it "has a combined x_origin" do
@@ -212,7 +218,7 @@ RSpec.describe GDAL::GeoTransform do
       end
 
       it "returns a new GeoTransform" do
-        expect(subject).to be_a GDAL::GeoTransform
+        expect(subject).to be_a described_class
       end
 
       it "returns an inverted x_origin" do

--- a/spec/unit/gdal/grid_spec.rb
+++ b/spec/unit/gdal/grid_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe GDAL::Grid do
     it { is_expected.to respond_to :data_type= }
     it { is_expected.to respond_to :algorithm_options }
     it { is_expected.to respond_to :algorithm_type }
-    it { is_expected.to respond_to :algorithm_type }
   end
 
   describe "#create" do
@@ -44,46 +43,55 @@ RSpec.describe GDAL::Grid do
   describe "#init_algorithm" do
     context "inverse_distance_to_a_power" do
       subject { grid.send(:init_algorithm, :inverse_distance_to_a_power) }
+
       it { is_expected.to be_an_instance_of(GDAL::GridAlgorithms::InverseDistanceToAPower) }
     end
 
     context "moving_average" do
       subject { grid.send(:init_algorithm, :moving_average) }
+
       it { is_expected.to be_an_instance_of(GDAL::GridAlgorithms::MovingAverage) }
     end
 
     context "nearest_neighbor" do
       subject { grid.send(:init_algorithm, :nearest_neighbor) }
+
       it { is_expected.to be_an_instance_of(GDAL::GridAlgorithms::NearestNeighbor) }
     end
 
     context "metric_average_distance" do
       subject { grid.send(:init_algorithm, :metric_average_distance) }
+
       it { is_expected.to be_an_instance_of(GDAL::GridAlgorithms::MetricAverageDistance) }
     end
 
     context "metric_average_distance_pts" do
       subject { grid.send(:init_algorithm, :metric_average_distance_pts) }
+
       it { is_expected.to be_an_instance_of(GDAL::GridAlgorithms::MetricAverageDistancePts) }
     end
 
     context "metric_count" do
       subject { grid.send(:init_algorithm, :metric_count) }
+
       it { is_expected.to be_an_instance_of(GDAL::GridAlgorithms::MetricCount) }
     end
 
     context "metric_maximum" do
       subject { grid.send(:init_algorithm, :metric_maximum) }
+
       it { is_expected.to be_an_instance_of(GDAL::GridAlgorithms::MetricMaximum) }
     end
 
     context "metric_minimum" do
       subject { grid.send(:init_algorithm, :metric_minimum) }
+
       it { is_expected.to be_an_instance_of(GDAL::GridAlgorithms::MetricMinimum) }
     end
 
     context "metric_range" do
       subject { grid.send(:init_algorithm, :metric_range) }
+
       it { is_expected.to be_an_instance_of(GDAL::GridAlgorithms::MetricRange) }
     end
 

--- a/spec/unit/gdal/internal_helpers_spec.rb
+++ b/spec/unit/gdal/internal_helpers_spec.rb
@@ -62,51 +62,61 @@ RSpec.describe GDAL::InternalHelpers do
   describe "._gdal_data_type_to_ffi" do
     context "data type is :GDT_Byte" do
       subject { tester._gdal_data_type_to_ffi(:GDT_Byte) }
+
       it { is_expected.to eq :uchar }
     end
 
     context "data type is :GDT_Int8" do
       subject { tester._gdal_data_type_to_ffi(:GDT_Int8) }
+
       it { is_expected.to eq :int8 }
     end
 
     context "data type is :GDT_UInt16" do
       subject { tester._gdal_data_type_to_ffi(:GDT_UInt16) }
+
       it { is_expected.to eq :uint16 }
     end
 
     context "data type is :GDT_Int16" do
       subject { tester._gdal_data_type_to_ffi(:GDT_Int16) }
+
       it { is_expected.to eq :int16 }
     end
 
     context "data type is :GDT_UInt32" do
       subject { tester._gdal_data_type_to_ffi(:GDT_UInt32) }
+
       it { is_expected.to eq :uint32 }
     end
 
     context "data type is :GDT_Int32" do
       subject { tester._gdal_data_type_to_ffi(:GDT_Int32) }
+
       it { is_expected.to eq :int32 }
     end
 
     context "data type is :GDT_UInt64" do
       subject { tester._gdal_data_type_to_ffi(:GDT_UInt64) }
+
       it { is_expected.to eq :uint64 }
     end
 
     context "data type is :GDT_Int64" do
       subject { tester._gdal_data_type_to_ffi(:GDT_Int64) }
+
       it { is_expected.to eq :int64 }
     end
 
     context "data type is :GDT_Float32" do
       subject { tester._gdal_data_type_to_ffi(:GDT_Float32) }
+
       it { is_expected.to eq :float }
     end
 
     context "data type is :GDT_Float64" do
       subject { tester._gdal_data_type_to_ffi(:GDT_Float64) }
+
       it { is_expected.to eq :double }
     end
 
@@ -169,12 +179,14 @@ RSpec.describe GDAL::InternalHelpers do
   describe "._supported?" do
     context "function is supported" do
       subject { tester._supported?(:GDALAllRegister) }
-      it { is_expected.to eq true }
+
+      it { is_expected.to be true }
     end
 
     context "function is not supported" do
       subject { tester._supported?(:darrells) }
-      it { is_expected.to eq false }
+
+      it { is_expected.to be false }
     end
   end
 
@@ -183,56 +195,67 @@ RSpec.describe GDAL::InternalHelpers do
 
     context "data_type is :GDT_Byte" do
       let(:data_type) { :GDT_Byte }
+
       it { is_expected.to eq(:byte) }
     end
 
     context "data_type is :GDT_Int16" do
       let(:data_type) { :GDT_Int16 }
+
       it { is_expected.to eq(:sint) }
     end
 
     context "data_type is :GDT_UInt16" do
       let(:data_type) { :GDT_UInt16 }
+
       it { is_expected.to eq(:int) }
     end
 
     context "data_type is :GDT_Int32" do
       let(:data_type) { :GDT_Int32 }
+
       it { is_expected.to eq(:int) }
     end
 
     context "data_type is :GDT_UInt32" do
       let(:data_type) { :GDT_UInt32 }
+
       it { is_expected.to eq(:int) }
     end
 
     context "data_type is :GDT_Float32" do
       let(:data_type) { :GDT_Float32 }
+
       it { is_expected.to eq(:float) }
     end
 
     context "data_type is :GDT_Float64" do
       let(:data_type) { :GDT_Float64 }
+
       it { is_expected.to eq(:dfloat) }
     end
 
     context "data_type is :GDT_CInt16" do
       let(:data_type) { :GDT_CInt16 }
+
       it { is_expected.to eq(:scomplex) }
     end
 
     context "data_type is :GDT_CInt32" do
       let(:data_type) { :GDT_CInt32 }
+
       it { is_expected.to eq(:scomplex) }
     end
 
     context "data_type is :GDT_CFloat32" do
       let(:data_type) { :GDT_CFloat32 }
+
       it { is_expected.to eq(:complex) }
     end
 
     context "data_type is :GDT_CFloat64" do
       let(:data_type) { :GDT_CFloat64 }
+
       it { is_expected.to eq(:dcomplex) }
     end
 
@@ -247,6 +270,7 @@ RSpec.describe GDAL::InternalHelpers do
   describe "._narray_from_data_type" do
     context "0 narray_args and known GDAL data_type" do
       subject { GDAL._narray_from_data_type(:GDT_Byte) }
+
       it { is_expected.to be_a NArray }
 
       it "has size 0" do
@@ -260,6 +284,7 @@ RSpec.describe GDAL::InternalHelpers do
 
     context "1 narray_args and known GDAL data_type" do
       subject { GDAL._narray_from_data_type(:GDT_Byte, 2) }
+
       it { is_expected.to be_a NArray }
 
       it "has size of the 2nd param" do
@@ -273,6 +298,7 @@ RSpec.describe GDAL::InternalHelpers do
 
     context "2 narray_args and known GDAL data_type" do
       subject { GDAL._narray_from_data_type(:GDT_Byte, 2, 3) }
+
       it { is_expected.to be_a NArray }
 
       it "has size of the 2nd param * 3rd param" do

--- a/spec/unit/gdal/major_object_spec.rb
+++ b/spec/unit/gdal/major_object_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe GDAL::MajorObject do
   let(:driver) { GDAL::Driver.by_name("GTiff") }
   let(:dataset) { driver.create_dataset("/vsimem/test-#{SecureRandom.uuid}.tif", 1, 1) }
   let(:band) { dataset.raster_band(1) }
+
   after { dataset.close }
 
   describe "#description" do

--- a/spec/unit/gdal/utils/dem_spec.rb
+++ b/spec/unit/gdal/utils/dem_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe GDAL::Utils::DEM do
   end
 
   let(:src_dataset) { GDAL::Dataset.open(src_dataset_path, "r") }
+
   after { src_dataset.close }
 
   describe ".perform" do
@@ -56,7 +57,7 @@ RSpec.describe GDAL::Utils::DEM do
     end
 
     context "when operation fails with GDAL internal exception" do
-      it "raises exception" do
+      it "raises exception for an invalid processing mode" do
         expected_messages = [
           "Invalid processing mode: hillshade123", # GDAL 3.10+
           "Invalid processing" # GDAL < 3.10
@@ -75,7 +76,7 @@ RSpec.describe GDAL::Utils::DEM do
         # rubocop:enable Style/MultilineBlockChain
       end
 
-      it "raises exception" do
+      it "raises exception for an invalid band number" do
         options = GDAL::Utils::DEM::Options.new(options: ["-b", "100"])
 
         expect do

--- a/spec/unit/gdal/utils/grid_spec.rb
+++ b/spec/unit/gdal/utils/grid_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe GDAL::Utils::Grid do
   end
 
   let(:src_dataset) { OGR::DataSource.open(src_dataset_path, "r") }
+
   after { src_dataset.close }
 
   describe ".perform" do

--- a/spec/unit/gdal/utils/info_spec.rb
+++ b/spec/unit/gdal/utils/info_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe GDAL::Utils::Info do
   end
 
   let(:dataset) { GDAL::Dataset.open(src_dataset_path, "r") }
+
   after { dataset.close }
 
   describe ".perform" do

--- a/spec/unit/gdal/utils/nearblack_spec.rb
+++ b/spec/unit/gdal/utils/nearblack_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe GDAL::Utils::Nearblack do
   end
 
   let(:src_dataset) { GDAL::Dataset.open(src_dataset_path, "r") }
+
   after { src_dataset.close }
 
   describe ".perform" do

--- a/spec/unit/gdal/utils/rasterize_spec.rb
+++ b/spec/unit/gdal/utils/rasterize_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe GDAL::Utils::Rasterize do
   end
 
   let(:src_dataset) { OGR::DataSource.open(src_dataset_path, "r") }
+
   after { src_dataset.close }
 
   describe ".perform" do

--- a/spec/unit/gdal/utils/translate_spec.rb
+++ b/spec/unit/gdal/utils/translate_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe GDAL::Utils::Translate do
   end
 
   let(:src_dataset) { GDAL::Dataset.open(src_dataset_path, "r") }
+
   after { src_dataset.close }
 
   describe ".perform" do

--- a/spec/unit/gdal/utils/vector_translate_spec.rb
+++ b/spec/unit/gdal/utils/vector_translate_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe GDAL::Utils::VectorTranslate do
   end
 
   let(:src_dataset) { OGR::DataSource.open(src_dataset_path, "r") }
+
   after { src_dataset.close }
 
   describe ".perform" do
@@ -65,6 +66,7 @@ RSpec.describe GDAL::Utils::VectorTranslate do
       let(:dst_dataset) do
         OGR::Driver.by_name("GeoJSON").create_data_source("/vsimem/test-#{SecureRandom.uuid}.geojson")
       end
+
       after { dst_dataset.close }
 
       context "when no options are provided" do

--- a/spec/unit/gdal/utils/warp_spec.rb
+++ b/spec/unit/gdal/utils/warp_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe GDAL::Utils::Warp do
   end
 
   let(:src_dataset) { GDAL::Dataset.open(src_dataset_path, "r") }
+
   after { src_dataset.close }
 
   describe ".perform" do
@@ -85,6 +86,7 @@ RSpec.describe GDAL::Utils::Warp do
 
         dataset
       end
+
       after { dst_dataset.close }
 
       context "when no options are provided" do

--- a/spec/unit/gdal/virtual_dataset_spec.rb
+++ b/spec/unit/gdal/virtual_dataset_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe GDAL::VirtualDataset do
   subject(:virtual_dataset) { described_class.new(300, 200) }
 
   describe "#initialize" do
-    it { is_expected.to be_a GDAL::VirtualDataset }
+    it { is_expected.to be_a described_class }
   end
 
   describe "#flush_cache" do
-    it "does something" do
-      subject.flush_cache
+    it "does not raise" do
+      expect { subject.flush_cache }.not_to raise_error
     end
   end
 

--- a/spec/unit/gdal/warp_options_spec.rb
+++ b/spec/unit/gdal/warp_options_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe GDAL::WarpOptions do
         expect(subject.destination_no_data_real).to eq([])
         expect(subject.destination_no_data_imaginary).to eq([])
 
-        expect(subject.progress).to_not be_null
+        expect(subject.progress).not_to be_null
         expect(subject.progress_arg).to be_null
 
         expect(subject.transformer).to be_null
@@ -97,6 +97,23 @@ RSpec.describe GDAL::WarpOptions do
     end
 
     context "passing in options that are also accessor methods" do
+      subject do
+        described_class.new warp_operation_options: warp_operation_options,
+                            source_dataset: source_dataset,
+                            destination_dataset: dest_dataset,
+                            source_bands: [1, 2, 3],
+                            destination_bands: [2, 4, 6],
+                            cutline: cutline,
+                            source_no_data_real: [123.456, 78.9, -999.9],
+                            source_no_data_imaginary: [1.2, 3.4, -5.6],
+                            destination_no_data_real: [11.1, 22.2, 33.3],
+                            destination_no_data_imaginary: [-44.4, -55.5, -66.6],
+                            source_per_band_validity_mask_function: [
+                              spb_validity_mask_function1,
+                              spb_validity_mask_function2
+                            ]
+      end
+
       let(:warp_operation_options) do
         {
           init_dest: "NODATA",
@@ -116,23 +133,6 @@ RSpec.describe GDAL::WarpOptions do
       after do
         source_dataset.close
         dest_dataset.close
-      end
-
-      subject do
-        described_class.new warp_operation_options: warp_operation_options,
-                            source_dataset: source_dataset,
-                            destination_dataset: dest_dataset,
-                            source_bands: [1, 2, 3],
-                            destination_bands: [2, 4, 6],
-                            cutline: cutline,
-                            source_no_data_real: [123.456, 78.9, -999.9],
-                            source_no_data_imaginary: [1.2, 3.4, -5.6],
-                            destination_no_data_real: [11.1, 22.2, 33.3],
-                            destination_no_data_imaginary: [-44.4, -55.5, -66.6],
-                            source_per_band_validity_mask_function: [
-                              spb_validity_mask_function1,
-                              spb_validity_mask_function2
-                            ]
       end
 
       it_behaves_like "a WarpOptions object"
@@ -190,7 +190,7 @@ RSpec.describe GDAL::WarpOptions do
         expect(function_ptr).to be_a(FFI::Pointer)
 
         function = function_ptr.read_pointer
-        expect(function).to_not be_null
+        expect(function).not_to be_null
       end
     end
 
@@ -200,17 +200,6 @@ RSpec.describe GDAL::WarpOptions do
         i.write_int(int)
         i
       end
-
-      let(:progress) { proc { true } }
-      let(:test_mask_function) { proc { true } }
-
-      let(:source_per_band_validity_mask_function_arg) { make_int_pointer(5) }
-      let(:source_validity_mask_function_arg) { make_int_pointer(3) }
-      let(:source_density_mask_function_arg) { make_int_pointer(2) }
-      let(:destination_validity_mask_function_arg) { make_int_pointer(4) }
-      let(:destination_density_mask_function_arg) { make_int_pointer(11) }
-      let(:pre_warp_processor_arg) { make_int_pointer(7) }
-      let(:post_warp_processor_arg) { make_int_pointer(9) }
 
       subject do
         described_class.new warp_memory_limit: 123,
@@ -236,6 +225,17 @@ RSpec.describe GDAL::WarpOptions do
                             post_warp_processor_arg: post_warp_processor_arg,
                             cutline_blend_distance: 3.3
       end
+
+      let(:progress) { proc { true } }
+      let(:test_mask_function) { proc { true } }
+
+      let(:source_per_band_validity_mask_function_arg) { make_int_pointer(5) }
+      let(:source_validity_mask_function_arg) { make_int_pointer(3) }
+      let(:source_density_mask_function_arg) { make_int_pointer(2) }
+      let(:destination_validity_mask_function_arg) { make_int_pointer(4) }
+      let(:destination_density_mask_function_arg) { make_int_pointer(11) }
+      let(:pre_warp_processor_arg) { make_int_pointer(7) }
+      let(:post_warp_processor_arg) { make_int_pointer(9) }
 
       it_behaves_like "a WarpOptions object"
 
@@ -274,7 +274,7 @@ RSpec.describe GDAL::WarpOptions do
       end
 
       it "sets source_validity_mask_function" do
-        expect(subject.source_validity_mask_function).to_not be_null
+        expect(subject.source_validity_mask_function).not_to be_null
       end
 
       it "sets source_validity_mask_function_arg" do
@@ -284,7 +284,7 @@ RSpec.describe GDAL::WarpOptions do
       end
 
       it "sets source_density_mask_function" do
-        expect(subject.source_density_mask_function).to_not be_null
+        expect(subject.source_density_mask_function).not_to be_null
       end
 
       it "sets source_density_mask_function_arg" do
@@ -294,7 +294,7 @@ RSpec.describe GDAL::WarpOptions do
       end
 
       it "sets destination_validity_mask_function" do
-        expect(subject.destination_validity_mask_function).to_not be_null
+        expect(subject.destination_validity_mask_function).not_to be_null
       end
 
       it "sets destination_validity_mask_function_arg" do
@@ -304,7 +304,7 @@ RSpec.describe GDAL::WarpOptions do
       end
 
       it "sets destination_density_mask_function" do
-        expect(subject.destination_density_mask_function).to_not be_null
+        expect(subject.destination_density_mask_function).not_to be_null
       end
 
       it "sets destination_density_mask_function_arg" do
@@ -318,7 +318,7 @@ RSpec.describe GDAL::WarpOptions do
       end
 
       it "sets pre_warp_chunk_processor_arg" do
-        expect(subject.pre_warp_processor_arg).to_not be_null
+        expect(subject.pre_warp_processor_arg).not_to be_null
       end
 
       it "sets post_warp_chunk_processor" do
@@ -326,7 +326,7 @@ RSpec.describe GDAL::WarpOptions do
       end
 
       it "sets post_warp_chunk_processor_arg" do
-        expect(subject.post_warp_processor_arg).to_not be_null
+        expect(subject.post_warp_processor_arg).not_to be_null
       end
 
       it "sets cutline_blend_distance" do

--- a/spec/unit/ogr/coordinate_transformation_spec.rb
+++ b/spec/unit/ogr/coordinate_transformation_spec.rb
@@ -3,6 +3,8 @@
 require "ogr/coordinate_transformation"
 
 RSpec.describe OGR::CoordinateTransformation do
+  subject { described_class.new(source_srs, dest_srs) }
+
   let(:source_srs) do
     OGR::SpatialReference.new.import_from_epsg(3857).tap do |srs|
       # NOTE: GDAL 3 changed default axis order: https://github.com/OSGeo/gdal/issues/1546
@@ -23,8 +25,6 @@ RSpec.describe OGR::CoordinateTransformation do
   let(:epsg4326_x_bounds) { [-180.0, 180.0] }
   let(:epsg3857_y_bounds) { [-20_048_966.10, 20_048_966.10] }
   let(:epsg3857_x_bounds) { [-20_026_376.39, 20_026_376.39] }
-
-  subject { described_class.new(source_srs, dest_srs) }
 
   describe ".proj4_normalize" do
     context "OCTProj4Normalize not supported" do

--- a/spec/unit/ogr/data_source_spec.rb
+++ b/spec/unit/ogr/data_source_spec.rb
@@ -4,6 +4,12 @@ require "ogr/data_source"
 require "ogr/spatial_reference"
 
 RSpec.describe OGR::DataSource do
+  subject(:data_source) do
+    driver.create_data_source("spec")
+  end
+
+  let(:driver) { OGR::Driver.by_name "Memory" }
+
   describe ".open" do
     context "not a data source" do
       it "raises an OGR::OpenFailure" do
@@ -14,7 +20,7 @@ RSpec.describe OGR::DataSource do
     end
 
     context "block given" do
-      let(:data_source) { instance_double "OGR::DataSource" }
+      let(:data_source) { instance_double described_class }
 
       it "yields then closes the opened DataSource" do
         allow(described_class).to receive(:new).and_return data_source
@@ -26,36 +32,36 @@ RSpec.describe OGR::DataSource do
     end
   end
 
-  let(:driver) { OGR::Driver.by_name "Memory" }
-
-  subject(:data_source) do
-    driver.create_data_source("spec")
-  end
-
   describe "#name" do
     subject { data_source.name }
+
     it { is_expected.to eq "spec" }
   end
 
   describe "#driver" do
     subject { data_source.driver.name }
+
     it { is_expected.to eq "Memory" }
   end
 
   describe "#layer_count" do
     subject { data_source.layer_count }
+
     it { is_expected.to be_zero }
   end
 
   describe "#layer" do
     context "no layers" do
       subject { data_source.layer(0) }
+
       it { is_expected.to be_nil }
     end
 
     context "1 layer" do
-      before { data_source.create_layer "unknown layer" }
       subject { data_source.layer(0) }
+
+      before { data_source.create_layer "unknown layer" }
+
       it { is_expected.to be_a OGR::Layer }
     end
   end
@@ -63,12 +69,15 @@ RSpec.describe OGR::DataSource do
   describe "#layer_by_name" do
     context "no layers" do
       subject { data_source.layer_by_name "meow" }
+
       it { is_expected.to be_nil }
     end
 
     context "1 layer" do
-      before { data_source.create_layer "unknown layer" }
       subject { data_source.layer_by_name "unknown layer" }
+
+      before { data_source.create_layer "unknown layer" }
+
       it { is_expected.to be_a OGR::Layer }
     end
   end
@@ -89,7 +98,7 @@ RSpec.describe OGR::DataSource do
         it "adds a new OGR::Layer to @layers" do
           expect do
             data_source.create_layer("unknown layer")
-          end.to change { data_source.layer_count }.by 1
+          end.to change(data_source, :layer_count).by 1
         end
 
         it "has a layer that is the given geometry type" do
@@ -102,7 +111,7 @@ RSpec.describe OGR::DataSource do
         it "adds a new OGR::Layer to @layers" do
           expect do
             data_source.create_layer("polygon layer", geometry_type: :wkbPolygon)
-          end.to change { data_source.layer_count }.by 1
+          end.to change(data_source, :layer_count).by 1
         end
 
         it "has a layer that is the given geometry type" do
@@ -117,7 +126,7 @@ RSpec.describe OGR::DataSource do
         it "adds a new OGR::Layer to @layers" do
           expect do
             data_source.create_layer("polygon layer", spatial_reference: spatial_reference)
-          end.to change { data_source.layer_count }.by 1
+          end.to change(data_source, :layer_count).by 1
         end
 
         it "has a layer that uses that spatial reference" do
@@ -134,7 +143,7 @@ RSpec.describe OGR::DataSource do
     it "adds a new OGR::Layer to @layers" do
       expect do
         subject.copy_layer(unknown_layer, "meow layer")
-      end.to change { subject.layer_count }.by 1
+      end.to change(subject, :layer_count).by 1
     end
 
     it "makes a copy of the layer" do
@@ -164,9 +173,11 @@ RSpec.describe OGR::DataSource do
       end
 
       context "1 layer" do
-        before { data_source.create_layer "unknown layer" }
         subject { data_source.delete_layer(0) }
-        it { is_expected.to eq nil }
+
+        before { data_source.create_layer "unknown layer" }
+
+        it { is_expected.to be_nil }
       end
     end
   end
@@ -174,6 +185,7 @@ RSpec.describe OGR::DataSource do
   describe "#style_table" do
     context "no associated style table" do
       subject { data_source.style_table }
+
       it { is_expected.to be_nil }
     end
   end
@@ -202,26 +214,26 @@ RSpec.describe OGR::DataSource do
       # I don't get why these return false...
       it "returns false" do
         capabilities.each do |capability|
-          expect(subject.test_capability(capability)).to eq false
+          expect(subject.test_capability(capability)).to be false
         end
       end
     end
 
     context "unsupported capabilities to check" do
       it "returns false" do
-        expect(subject.test_capability("meow")).to eq false
+        expect(subject.test_capability("meow")).to be false
       end
     end
   end
 
   describe "#sync_to_disk" do
     # NOTE: We redefine driver, as we should use file-based format to test #sync_to_disk.
-    let(:driver) { OGR::Driver.by_name("CSV") }
-    let(:tmpfile) { Tempfile.new(["spec", ".csv"]) }
-
     subject(:data_source) do
       driver.create_data_source(tmpfile.path)
     end
+
+    let(:driver) { OGR::Driver.by_name("CSV") }
+    let(:tmpfile) { Tempfile.new(["spec", ".csv"]) }
 
     it do
       expect(subject.sync_to_disk).to be_nil

--- a/spec/unit/ogr/driver_spec.rb
+++ b/spec/unit/ogr/driver_spec.rb
@@ -3,21 +3,26 @@
 require "ogr/driver"
 
 RSpec.describe OGR::Driver do
+  subject(:memory_driver) { described_class.by_name("Memory") }
+
+  let(:shapefile_driver) { described_class.by_name("ESRI Shapefile") }
+
   describe ".count" do
     subject { described_class.count }
+
     it { is_expected.to be_a Integer }
   end
 
   describe ".by_name" do
     it "can return an OGR::Driver" do
-      expect(described_class.by_name("Memory")).to be_a OGR::Driver
+      expect(described_class.by_name("Memory")).to be_a described_class
     end
   end
 
   describe ".at_index" do
     context "valid index" do
       it "returns an OGR::Driver" do
-        expect(described_class.at_index(0)).to be_a OGR::Driver
+        expect(described_class.at_index(0)).to be_a described_class
       end
     end
 
@@ -36,11 +41,9 @@ RSpec.describe OGR::Driver do
     end
   end
 
-  subject(:memory_driver) { described_class.by_name("Memory") }
-  let(:shapefile_driver) { described_class.by_name("ESRI Shapefile") }
-
   describe "#name" do
     subject { memory_driver.name }
+
     it { is_expected.to eq "Memory" }
   end
 

--- a/spec/unit/ogr/envelope_spec.rb
+++ b/spec/unit/ogr/envelope_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe OGR::Envelope do
   describe "#x_min" do
     context "default value" do
       subject { described_class.new.x_min }
+
       it { is_expected.to eq(0.0) }
     end
   end
@@ -21,6 +22,7 @@ RSpec.describe OGR::Envelope do
   describe "#x_max" do
     context "default value" do
       subject { described_class.new.x_max }
+
       it { is_expected.to eq(0.0) }
     end
   end
@@ -35,6 +37,7 @@ RSpec.describe OGR::Envelope do
   describe "#y_min" do
     context "default value" do
       subject { described_class.new.y_min }
+
       it { is_expected.to eq(0.0) }
     end
   end
@@ -49,6 +52,7 @@ RSpec.describe OGR::Envelope do
   describe "#y_max" do
     context "default value" do
       subject { described_class.new.y_max }
+
       it { is_expected.to eq(0.0) }
     end
   end
@@ -64,6 +68,7 @@ RSpec.describe OGR::Envelope do
     describe "#z_min" do
       context "default value" do
         subject { described_class.new.z_min }
+
         it { is_expected.to be_nil }
       end
     end
@@ -78,6 +83,7 @@ RSpec.describe OGR::Envelope do
     describe "#z_max" do
       context "default value" do
         subject { described_class.new.z_max }
+
         it { is_expected.to be_nil }
       end
     end
@@ -96,6 +102,7 @@ RSpec.describe OGR::Envelope do
     describe "#z_min" do
       context "default value" do
         subject { described_class.new.z_min }
+
         it { is_expected.to be_nil }
       end
     end
@@ -110,6 +117,7 @@ RSpec.describe OGR::Envelope do
     describe "#z_max" do
       context "default value" do
         subject { described_class.new.z_max }
+
         it { is_expected.to be_nil }
       end
     end

--- a/spec/unit/ogr/error_handling_spec.rb
+++ b/spec/unit/ogr/error_handling_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe OGR::ErrorHandling do
     context ":OGRERR_NONE" do
       it "does not raise" do
         expect { described_class.handle_ogr_err("") { :OGRERR_NONE } }
-          .to_not raise_exception
+          .not_to raise_exception
       end
     end
 

--- a/spec/unit/ogr/extensions/data_source/capability_methods_spec.rb
+++ b/spec/unit/ogr/extensions/data_source/capability_methods_spec.rb
@@ -10,22 +10,26 @@ RSpec.describe OGR::DataSource do
 
     describe "#can_create_layer?" do
       subject { data_source.can_create_layer? }
-      it { is_expected.to eq true }
+
+      it { is_expected.to be true }
     end
 
     describe "#can_delete_layer?" do
       subject { data_source.can_delete_layer? }
-      it { is_expected.to eq true }
+
+      it { is_expected.to be true }
     end
 
     describe "#can_create_geometry_field_after_create_layer?" do
       subject { data_source.can_create_geometry_field_after_create_layer? }
-      it { is_expected.to eq true }
+
+      it { is_expected.to be true }
     end
 
     describe "#supports_curve_geometries?" do
       subject { data_source.supports_curve_geometries? }
-      it { is_expected.to eq true }
+
+      it { is_expected.to be true }
     end
   end
 end

--- a/spec/unit/ogr/extensions/driver/capability_methods_spec.rb
+++ b/spec/unit/ogr/extensions/driver/capability_methods_spec.rb
@@ -5,11 +5,12 @@ require "ogr/extensions/driver/capability_methods"
 
 RSpec.describe OGR::Driver do
   context "Memory driver" do
-    subject(:driver) { OGR::Driver.by_name("Memory") }
+    subject(:driver) { described_class.by_name("Memory") }
 
     describe "#can_create_data_source?" do
       subject { driver.can_create_data_source? }
-      it { is_expected.to eq true }
+
+      it { is_expected.to be true }
     end
 
     describe "#can_delete_data_source?" do

--- a/spec/unit/ogr/extensions/envelope/extensions_spec.rb
+++ b/spec/unit/ogr/extensions/envelope/extensions_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe OGR::Envelope::Extensions do
       end
 
       it "returns true" do
-        expect(subject == other_envelope).to eq true
+        expect(subject == other_envelope).to be true
       end
     end
 
@@ -67,7 +67,7 @@ RSpec.describe OGR::Envelope::Extensions do
       end
 
       it "returns false" do
-        expect(subject == other_envelope).to eq false
+        expect(subject == other_envelope).to be false
       end
     end
   end
@@ -131,7 +131,7 @@ RSpec.describe OGR::Envelope::Extensions do
       end
 
       it "returns true" do
-        expect(subject.intersects?(other_envelope)).to eq true
+        expect(subject.intersects?(other_envelope)).to be true
       end
     end
 
@@ -147,7 +147,7 @@ RSpec.describe OGR::Envelope::Extensions do
       end
 
       it "returns false" do
-        expect(subject.intersects?(other_envelope)).to eq false
+        expect(subject.intersects?(other_envelope)).to be false
       end
     end
   end
@@ -172,7 +172,7 @@ RSpec.describe OGR::Envelope::Extensions do
       end
 
       it "returns true" do
-        expect(subject.contains?(other_envelope)).to eq true
+        expect(subject.contains?(other_envelope)).to be true
       end
     end
 
@@ -188,7 +188,7 @@ RSpec.describe OGR::Envelope::Extensions do
       end
 
       it "returns false" do
-        expect(subject.contains?(other_envelope)).to eq false
+        expect(subject.contains?(other_envelope)).to be false
       end
     end
   end

--- a/spec/unit/ogr/extensions/feature/extensions_spec.rb
+++ b/spec/unit/ogr/extensions/feature/extensions_spec.rb
@@ -3,6 +3,13 @@
 require "ogr/extensions/feature/extensions"
 
 RSpec.describe OGR::Feature::Extensions do
+  subject(:feature) do
+    f = OGR::Feature.new(feature_definition)
+    f.set_geometry_field(0, geometry)
+
+    f
+  end
+
   let(:integer_field_def) { OGR::FieldDefinition.new("test integer field", :OFTInteger) }
 
   let(:feature_definition) do
@@ -17,13 +24,6 @@ RSpec.describe OGR::Feature::Extensions do
   end
 
   let(:geometry) { OGR::Point.create_from_wkt("POINT (0 1)") }
-
-  subject(:feature) do
-    f = OGR::Feature.new(feature_definition)
-    f.set_geometry_field(0, geometry)
-
-    f
-  end
 
   describe "#each_field" do
     context "no block given" do

--- a/spec/unit/ogr/extensions/geometry/container_mixins_spec.rb
+++ b/spec/unit/ogr/extensions/geometry/container_mixins_spec.rb
@@ -2,6 +2,10 @@
 
 require "ogr/extensions/geometry/container_mixins"
 
+# This file exercises the container-geometry mixin across each concrete
+# container class; the separate top-level describes are intentional (one per
+# class) rather than nested.
+# rubocop:disable RSpec/MultipleDescribes
 RSpec.describe OGR::GeometryCollection do
   describe "#collection" do
     it { is_expected.to be_collection }
@@ -9,6 +13,7 @@ RSpec.describe OGR::GeometryCollection do
 
   describe "#each" do
     subject { described_class.new.each }
+
     it { is_expected.to be_a Enumerator }
   end
 
@@ -46,3 +51,4 @@ RSpec.describe OGR::Polygon do
     let(:child_geometry) { OGR::LinearRing.new }
   end
 end
+# rubocop:enable RSpec/MultipleDescribes

--- a/spec/unit/ogr/extensions/geometry/ewkb_record_spec.rb
+++ b/spec/unit/ogr/extensions/geometry/ewkb_record_spec.rb
@@ -28,9 +28,9 @@ RSpec.describe OGR::Geometry::EWKBRecord do
         expect(subject.endianness.value).to eq 1
 
         expect(subject.wkb_type.value).to eq 1
-        expect(subject.has_z?).to eq false
-        expect(subject.has_m?).to eq false
-        expect(subject.has_srid?).to eq false
+        expect(subject.has_z?).to be false
+        expect(subject.has_m?).to be false
+        expect(subject.has_srid?).to be false
 
         expect(subject.srid.value).to eq 0
         expect(subject.geometry.value).to be_a String
@@ -46,9 +46,9 @@ RSpec.describe OGR::Geometry::EWKBRecord do
 
         expect(subject.wkb_type.value).to eq(subject.geometry_type | 0x2000_0000)
         expect(subject.geometry_type).to eq 1
-        expect(subject.has_z?).to eq false
-        expect(subject.has_m?).to eq false
-        expect(subject.has_srid?).to eq true
+        expect(subject.has_z?).to be false
+        expect(subject.has_m?).to be false
+        expect(subject.has_srid?).to be true
 
         expect(subject.srid.value).to eq 3857
 
@@ -64,9 +64,9 @@ RSpec.describe OGR::Geometry::EWKBRecord do
         expect(subject.endianness.value).to eq 1
 
         expect(subject.wkb_type.value).to eq(subject.geometry_type | 0x8000_0000)
-        expect(subject.has_z?).to eq true
-        expect(subject.has_m?).to eq false
-        expect(subject.has_srid?).to eq false
+        expect(subject.has_z?).to be true
+        expect(subject.has_m?).to be false
+        expect(subject.has_srid?).to be false
 
         expect(subject.srid.value).to eq 0
         expect(subject.geometry.value).to be_a String
@@ -82,9 +82,9 @@ RSpec.describe OGR::Geometry::EWKBRecord do
 
         expect(subject.wkb_type.value).to eq(0x8000_0000 | 0x2000_0000 | subject.geometry_type)
         expect(subject.geometry_type).to eq(subject.wkb_type.value ^ 0x2000_0000)
-        expect(subject.has_z?).to eq true
-        expect(subject.has_m?).to eq false
-        expect(subject.has_srid?).to eq true
+        expect(subject.has_z?).to be true
+        expect(subject.has_m?).to be false
+        expect(subject.has_srid?).to be true
 
         expect(subject.srid.value).to eq 3857
 
@@ -103,21 +103,25 @@ RSpec.describe OGR::Geometry::EWKBRecord do
 
     context "point, no srid" do
       subject { described_class.read(ewkb_point_no_srid).to_wkb }
+
       it_behaves_like "a WKB string"
     end
 
     context "point, SRID" do
       subject { described_class.read(ewkb_point_with_srid).to_wkb }
+
       it_behaves_like "a WKB string"
     end
 
     context "point25d, no srid" do
       subject { described_class.read(ewkb_point25d_no_srid).to_wkb }
+
       it_behaves_like "a WKB string"
     end
 
     context "point25d, SRID" do
       subject { described_class.read(ewkb_point25d_with_srid).to_wkb }
+
       it_behaves_like "a WKB string"
     end
   end
@@ -136,21 +140,25 @@ RSpec.describe OGR::Geometry::EWKBRecord do
 
     context "point, no srid" do
       let(:ewkb_record) { described_class.read(ewkb_point_no_srid) }
+
       it_behaves_like "a WKBRecord"
     end
 
     context "point, SRID" do
       let(:ewkb_record) { described_class.read(ewkb_point_with_srid) }
+
       it_behaves_like "a WKBRecord"
     end
 
     context "point25d, no srid" do
       let(:ewkb_record) { described_class.read(ewkb_point25d_no_srid) }
+
       it_behaves_like "a WKBRecord"
     end
 
     context "point25d, SRID" do
       let(:ewkb_record) { described_class.read(ewkb_point25d_with_srid) }
+
       it_behaves_like "a WKBRecord"
     end
   end

--- a/spec/unit/ogr/extensions/geometry/extensions_spec.rb
+++ b/spec/unit/ogr/extensions/geometry/extensions_spec.rb
@@ -5,7 +5,7 @@ OGR::MultiPolygon.include(OGR::Geometry)
 
 RSpec.describe OGR::Geometry do
   describe "#utm_zone" do
-    let(:geom) { OGR::Geometry.create_from_wkt(wkt) }
+    let(:geom) { described_class.create_from_wkt(wkt) }
 
     let(:wkt) do
       "LINESTRING (100 100, 20 20, 30 30, 100 100)"
@@ -13,11 +13,13 @@ RSpec.describe OGR::Geometry do
 
     context "no spatial_reference" do
       subject { geom.utm_zone }
+
       it { is_expected.to be_nil }
     end
 
     context "SRID is 4326" do
       subject { geom.utm_zone }
+
       before { geom.spatial_reference = OGR::SpatialReference.new.import_from_epsg(4326) }
 
       context "geometry is valid" do

--- a/spec/unit/ogr/extensions/geometry/rttopo_extensions_spec.rb
+++ b/spec/unit/ogr/extensions/geometry/rttopo_extensions_spec.rb
@@ -7,7 +7,7 @@ require "ogr/extensions/geometry/rttopo_extensions"
 # results in tests here.
 #
 RSpec.describe OGR::Geometry do
-  subject { OGR::Geometry.create_from_wkt(wkt) }
+  subject { described_class.create_from_wkt(wkt) }
 
   shared_context "shared point, no crossing" do
     let(:wkt) do

--- a/spec/unit/ogr/extensions/geometry/wkb_record_spec.rb
+++ b/spec/unit/ogr/extensions/geometry/wkb_record_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe OGR::Geometry::WKBRecord do
         expect(subject).to be_a described_class
         expect(subject.endianness.value).to eq FFI::OGR::Core::WKBByteOrder[:wkbNDR]
         expect(subject.wkb_type.value).to eq FFI::OGR::Core::WKBGeometryType[:wkbPoint]
-        expect(subject.has_z?).to eq false
+        expect(subject.has_z?).to be false
         expect(subject.geometry.value).to be_a String
       end
     end
@@ -28,7 +28,7 @@ RSpec.describe OGR::Geometry::WKBRecord do
         expect(subject.endianness.value).to eq FFI::OGR::Core::WKBByteOrder[:wkbNDR]
         expect(subject.wkb_type.value).to eq 1001
         expect(subject.geometry_type).to eq(described_class::WKB_Z | FFI::OGR::Core::WKBGeometryType[:wkbPoint])
-        expect(subject.has_z?).to eq true
+        expect(subject.has_z?).to be true
         expect(subject.geometry.value).to be_a String
       end
     end

--- a/spec/unit/ogr/extensions/geometry_types/curve/extensions_spec.rb
+++ b/spec/unit/ogr/extensions/geometry_types/curve/extensions_spec.rb
@@ -24,12 +24,14 @@ RSpec.describe OGR::GeometryTypes::Curve::Extensions do
   describe "#closed?" do
     context "geometry is closed" do
       subject { closed_line_string }
+
       it { is_expected.to be_closed }
     end
 
     context "geometry is not closed" do
       subject { open_line_string }
-      it { is_expected.to_not be_closed }
+
+      it { is_expected.not_to be_closed }
     end
   end
 end

--- a/spec/unit/ogr/extensions/layer/capability_methods_spec.rb
+++ b/spec/unit/ogr/extensions/layer/capability_methods_spec.rb
@@ -8,82 +8,98 @@ RSpec.describe OGR::Layer do
 
     describe "#can_random_read?" do
       subject { layer.can_random_read? }
-      it { is_expected.to eq true }
+
+      it { is_expected.to be true }
     end
 
     describe "#can_sequential_write?" do
       subject { layer.can_sequential_write? }
-      it { is_expected.to eq true }
+
+      it { is_expected.to be true }
     end
 
     describe "#can_random_write?" do
       subject { layer.can_random_write? }
-      it { is_expected.to eq true }
+
+      it { is_expected.to be true }
     end
 
     describe "#can_fast_spatial_filter?" do
       subject { layer.can_fast_spatial_filter? }
-      it { is_expected.to eq false }
+
+      it { is_expected.to be false }
     end
 
     describe "#can_fast_feature_count?" do
       subject { layer.can_fast_feature_count? }
-      it { is_expected.to eq true }
+
+      it { is_expected.to be true }
     end
 
     describe "#can_fast_get_extent?" do
       subject { layer.can_fast_get_extent? }
-      it { is_expected.to eq false }
+
+      it { is_expected.to be false }
     end
 
     describe "#can_fast_set_next_by_index?" do
       subject { layer.can_fast_set_next_by_index? }
-      it { is_expected.to eq true }
+
+      it { is_expected.to be true }
     end
 
     describe "#can_create_field?" do
       subject { layer.can_create_field? }
-      it { is_expected.to eq true }
+
+      it { is_expected.to be true }
     end
 
     describe "#can_create_geometry_field?" do
       subject { layer.can_create_geometry_field? }
-      it { is_expected.to eq true }
+
+      it { is_expected.to be true }
     end
 
     describe "#can_delete_field?" do
       subject { layer.can_delete_field? }
-      it { is_expected.to eq true }
+
+      it { is_expected.to be true }
     end
 
     describe "#can_reorder_fields?" do
       subject { layer.can_reorder_fields? }
-      it { is_expected.to eq true }
+
+      it { is_expected.to be true }
     end
 
     describe "#can_alter_field_definition?" do
       subject { layer.can_alter_field_definition? }
-      it { is_expected.to eq true }
+
+      it { is_expected.to be true }
     end
 
     describe "#can_delete_feature?" do
       subject { layer.can_delete_feature? }
-      it { is_expected.to eq true }
+
+      it { is_expected.to be true }
     end
 
     describe "#strings_are_utf_8?" do
       subject { layer.strings_are_utf_8? }
-      it { is_expected.to eq false }
+
+      it { is_expected.to be false }
     end
 
     describe "#supports_transactions?" do
       subject { layer.supports_transactions? }
-      it { is_expected.to eq false }
+
+      it { is_expected.to be false }
     end
 
     describe "#supports_curve_geometries?" do
       subject { layer.supports_curve_geometries? }
-      it { is_expected.to eq true }
+
+      it { is_expected.to be true }
     end
   end
 end

--- a/spec/unit/ogr/feature_definition_spec.rb
+++ b/spec/unit/ogr/feature_definition_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe OGR::FeatureDefinition do
   describe "#field_count" do
     context "no fields" do
       subject { feature_definition.field_count }
+
       it { is_expected.to be_zero }
     end
 
@@ -98,6 +99,7 @@ RSpec.describe OGR::FeatureDefinition do
 
     context "field with requested name exists" do
       let(:field) { OGR::FieldDefinition.new("test field", :OFTString) }
+
       before { subject.add_field_definition(field) }
 
       it "returns the FieldDefinition's index" do
@@ -137,7 +139,8 @@ RSpec.describe OGR::FeatureDefinition do
   describe "#geometry_ignored?" do
     context "default" do
       subject { feature_definition.geometry_ignored? }
-      it { is_expected.to eq false }
+
+      it { is_expected.to be false }
     end
   end
 
@@ -145,14 +148,14 @@ RSpec.describe OGR::FeatureDefinition do
     context "set to ignore" do
       it "causes the geometry to be ignored" do
         subject.ignore_geometry!
-        expect(subject.geometry_ignored?).to eq true
+        expect(subject.geometry_ignored?).to be true
       end
     end
 
     context "set to not ignore" do
       it "causes the geometry to be ignored" do
         subject.ignore_geometry! ignore: false
-        expect(subject.geometry_ignored?).to eq false
+        expect(subject.geometry_ignored?).to be false
       end
     end
   end
@@ -160,7 +163,8 @@ RSpec.describe OGR::FeatureDefinition do
   describe "#style_ignored?" do
     context "default" do
       subject { feature_definition.style_ignored? }
-      it { is_expected.to eq false }
+
+      it { is_expected.to be false }
     end
   end
 
@@ -168,14 +172,14 @@ RSpec.describe OGR::FeatureDefinition do
     context "set to ignore" do
       it "causes the style to be ignored" do
         subject.ignore_style!
-        expect(subject.style_ignored?).to eq true
+        expect(subject.style_ignored?).to be true
       end
     end
 
     context "set to not ignore" do
       it "causes the style to be ignored" do
         subject.ignore_style! ignore: false
-        expect(subject.style_ignored?).to eq false
+        expect(subject.style_ignored?).to be false
       end
     end
   end
@@ -183,6 +187,7 @@ RSpec.describe OGR::FeatureDefinition do
   describe "#geometry_field_count" do
     context "default" do
       subject { feature_definition.geometry_field_count }
+
       it { is_expected.to eq 1 }
     end
   end
@@ -209,7 +214,7 @@ RSpec.describe OGR::FeatureDefinition do
     it "adds the geometry_field_definition" do
       expect do
         subject.add_geometry_field_definition geometry_field_definition
-      end.to change { subject.geometry_field_count }.by 1
+      end.to change(subject, :geometry_field_count).by 1
     end
   end
 
@@ -232,7 +237,7 @@ RSpec.describe OGR::FeatureDefinition do
       it "deletes the gfld" do
         expect do
           subject.delete_geometry_field_definition(1)
-        end.to change { subject.geometry_field_count }.by(-1)
+        end.to change(subject, :geometry_field_count).by(-1)
       end
     end
   end
@@ -246,7 +251,7 @@ RSpec.describe OGR::FeatureDefinition do
       end
 
       it "returns true" do
-        expect(subject.same?(other_feature_definition)).to eq true
+        expect(subject.same?(other_feature_definition)).to be true
       end
     end
 
@@ -256,7 +261,7 @@ RSpec.describe OGR::FeatureDefinition do
       end
 
       it "returns false" do
-        expect(subject.same?(other_feature_definition)).to eq false
+        expect(subject.same?(other_feature_definition)).to be false
       end
     end
   end

--- a/spec/unit/ogr/feature_spec.rb
+++ b/spec/unit/ogr/feature_spec.rb
@@ -5,6 +5,8 @@ require "ogr/feature"
 require "ogr/field"
 
 RSpec.describe OGR::Feature do
+  subject(:feature) { described_class.new(feature_definition) }
+
   let(:integer_field_def) { OGR::FieldDefinition.new("test integer field", :OFTInteger) }
   let(:integer_list_field_def) { OGR::FieldDefinition.new("test integer list field", :OFTIntegerList) }
   let(:real_field_def) { OGR::FieldDefinition.new("test real field", :OFTReal) }
@@ -47,17 +49,16 @@ RSpec.describe OGR::Feature do
     end
   end
 
-  subject(:feature) { described_class.new(feature_definition) }
-
   describe "#clone" do
     it "returns a new Feature" do
-      expect(subject.clone).to be_a OGR::Feature
+      expect(subject.clone).to be_a described_class
     end
   end
 
   describe "#field_count" do
     context "no fields" do
       subject { empty_feature_definition.field_count }
+
       it { is_expected.to be_zero }
     end
 
@@ -299,6 +300,7 @@ RSpec.describe OGR::Feature do
       end
     end
   end
+
   describe "#field_definition" do
     context "field exists at the given index" do
       it "returns the FieldDefinition" do
@@ -330,7 +332,7 @@ RSpec.describe OGR::Feature do
   describe "#field_set?" do
     context "field at the given index is not set" do
       it "returns false" do
-        expect(subject.field_set?(0)).to eq false
+        expect(subject.field_set?(0)).to be false
       end
     end
 
@@ -340,7 +342,7 @@ RSpec.describe OGR::Feature do
       end
 
       it "returns true" do
-        expect(subject.field_set?(0)).to eq true
+        expect(subject.field_set?(0)).to be true
       end
     end
   end
@@ -349,7 +351,7 @@ RSpec.describe OGR::Feature do
     context "field is set" do
       it "removes the field" do
         subject.unset_field(0)
-        expect(subject.field_set?(0)).to eq false
+        expect(subject.field_set?(0)).to be false
       end
     end
 

--- a/spec/unit/ogr/field_definition_spec.rb
+++ b/spec/unit/ogr/field_definition_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe OGR::FieldDefinition do
   describe "#ignored?" do
     context "default" do
       it "returns false" do
-        expect(subject).to_not be_ignored
+        expect(subject).not_to be_ignored
       end
     end
   end

--- a/spec/unit/ogr/field_spec.rb
+++ b/spec/unit/ogr/field_spec.rb
@@ -5,7 +5,7 @@ require "ogr/field"
 RSpec.describe OGR::Field do
   describe "#integer" do
     context "not set" do
-      it "returns 0.0" do
+      it "returns 0" do
         expect(subject.integer).to be 0
       end
     end
@@ -22,7 +22,7 @@ RSpec.describe OGR::Field do
 
   describe "#integer64" do
     context "not set" do
-      it "returns 0.0" do
+      it "returns 0" do
         expect(subject.integer64).to be 0
       end
     end

--- a/spec/unit/ogr/field_spec.rb
+++ b/spec/unit/ogr/field_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe OGR::Field do
   describe "#integer" do
     context "not set" do
       it "returns 0.0" do
-        expect(subject.integer).to eql 0
+        expect(subject.integer).to be 0
       end
     end
   end
@@ -23,7 +23,7 @@ RSpec.describe OGR::Field do
   describe "#integer64" do
     context "not set" do
       it "returns 0.0" do
-        expect(subject.integer64).to eql 0
+        expect(subject.integer64).to be 0
       end
     end
   end
@@ -40,7 +40,7 @@ RSpec.describe OGR::Field do
   describe "#real" do
     context "not set" do
       it "returns 0.0" do
-        expect(subject.real).to eql 0.0
+        expect(subject.real).to be 0.0
       end
     end
   end

--- a/spec/unit/ogr/geometries/geometry_collection_25d_spec.rb
+++ b/spec/unit/ogr/geometries/geometry_collection_25d_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe OGR::GeometryCollection25D do
   describe "#type" do
     context "when created with data" do
       subject { OGR::Geometry.create_from_wkt(wkt) }
+
       let(:wkt) { "GEOMETRYCOLLECTION(POINT(4 6 8),LINESTRING(4 6 8,7 10 11))" }
 
       it "returns :wkbGeometryCollection25D" do

--- a/spec/unit/ogr/geometries/geometry_collection_spec.rb
+++ b/spec/unit/ogr/geometries/geometry_collection_spec.rb
@@ -14,14 +14,14 @@ RSpec.describe OGR::GeometryCollection do
   end
 
   describe "#to_polygon" do
-    let(:polygon) do
-      OGR::Geometry.create_from_wkt("POLYGON ((0 0,0 1,1 1,1 0,0 0))")
-    end
-
     subject do
       gc = described_class.new
       gc.add_geometry(polygon)
       gc
+    end
+
+    let(:polygon) do
+      OGR::Geometry.create_from_wkt("POLYGON ((0 0,0 1,1 1,1 0,0 0))")
     end
 
     it "returns a Polygon" do
@@ -30,19 +30,19 @@ RSpec.describe OGR::GeometryCollection do
   end
 
   describe "#to_multi_polygon" do
+    subject do
+      gc = described_class.new
+      gc.add_geometry(polygon1)
+      gc.add_geometry(polygon2)
+      gc
+    end
+
     let(:polygon1) do
       OGR::Geometry.create_from_wkt("POLYGON ((0 0,0 1,1 1,1 0,0 0))")
     end
 
     let(:polygon2) do
       OGR::Geometry.create_from_wkt("POLYGON ((10 10,10 11,11 11,11 10,10 10))")
-    end
-
-    subject do
-      gc = described_class.new
-      gc.add_geometry(polygon1)
-      gc.add_geometry(polygon2)
-      gc
     end
 
     it "returns a MultiPolygon" do

--- a/spec/unit/ogr/geometries/line_string_25d_spec.rb
+++ b/spec/unit/ogr/geometries/line_string_25d_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe OGR::LineString25D do
   describe "#type" do
     context "when created with data" do
       subject { OGR::Geometry.create_from_wkt(wkt) }
+
       let(:wkt) { "LINESTRING(1 2 3, 2 2 3)" }
 
       it "returns :wkbLineString25D" do

--- a/spec/unit/ogr/geometries/line_string_spec.rb
+++ b/spec/unit/ogr/geometries/line_string_spec.rb
@@ -33,61 +33,68 @@ RSpec.describe OGR::LineString do
 
   describe "#name" do
     subject { open_line_string.name }
+
     it { is_expected.to eq "LINESTRING" }
   end
 
   describe "#point_count" do
     subject { open_line_string.point_count }
+
     it { is_expected.to eq 3 }
   end
 
   describe "#intersects?" do
     context "other geometry is a point" do
       context "inside the ring" do
+        subject { open_line_string.intersects?(other_geometry) }
+
         let(:other_geometry) do
           OGR::Geometry.create_from_wkt("POINT (0 1)")
         end
 
-        subject { open_line_string.intersects?(other_geometry) }
-        it { is_expected.to eq true }
+        it { is_expected.to be true }
       end
 
       context "on a vertex of the ring" do
+        subject { open_line_string.intersects?(other_geometry) }
+
         let(:other_geometry) do
           OGR::Geometry.create_from_wkt("POINT (0 0)")
         end
 
-        subject { open_line_string.intersects?(other_geometry) }
-        it { is_expected.to eq true }
+        it { is_expected.to be true }
       end
     end
 
     context "other geometry is a line string" do
       context "outside the ring" do
+        subject { open_line_string.intersects?(other_geometry) }
+
         let(:other_geometry) do
           OGR::Geometry.create_from_wkt("LINESTRING (100 100, 20 20)")
         end
 
-        subject { open_line_string.intersects?(other_geometry) }
-        it { is_expected.to eq false }
+        it { is_expected.to be false }
       end
 
       context "ends on a vertex" do
+        subject { open_line_string.intersects?(other_geometry) }
+
         let(:other_geometry) do
           OGR::Geometry.create_from_wkt("LINESTRING (50 50, 0 0)")
         end
 
-        subject { open_line_string.intersects?(other_geometry) }
-        it { is_expected.to eq true }
+        it { is_expected.to be true }
       end
 
       context "passes across the boundary" do
+        subject { open_line_string.intersects?(other_geometry) }
+
         let(:other_geometry) do
           OGR::Geometry.create_from_wkt("LINESTRING (15 5, 5 5)")
         end
 
-        subject { open_line_string.intersects?(other_geometry) }
-        it { is_expected.to eq false }
+        it { is_expected.to be false }
       end
     end
   end

--- a/spec/unit/ogr/geometries/linear_ring_spec.rb
+++ b/spec/unit/ogr/geometries/linear_ring_spec.rb
@@ -3,6 +3,8 @@
 require "ogr/geometry"
 
 RSpec.describe OGR::LinearRing do
+  subject { linear_ring }
+
   let(:linear_ring) do
     g = described_class.new
     g.add_point(0, 0)
@@ -22,65 +24,70 @@ RSpec.describe OGR::LinearRing do
     let(:geometry) { linear_ring }
   end
 
-  subject { linear_ring }
-
   describe "#name" do
     subject { linear_ring.name }
+
     it { is_expected.to eq "LINEARRING" }
   end
 
   describe "#point_count" do
     subject { linear_ring.point_count }
+
     it { is_expected.to eq 5 }
   end
 
   describe "#intersects?" do
     context "other geometry is a point" do
       context "inside the ring" do
+        subject { linear_ring.intersects?(other_geometry) }
+
         let(:other_geometry) do
           OGR::Geometry.create_from_wkt("POINT (0 1)")
         end
 
-        subject { linear_ring.intersects?(other_geometry) }
-        it { is_expected.to eq false }
+        it { is_expected.to be false }
       end
 
       context "on a vertex of the ring" do
+        subject { linear_ring.intersects?(other_geometry) }
+
         let(:other_geometry) do
           OGR::Geometry.create_from_wkt("POINT (0 0)")
         end
 
-        subject { linear_ring.intersects?(other_geometry) }
-        it { is_expected.to eq false }
+        it { is_expected.to be false }
       end
     end
 
     context "other geometry is a line string" do
       context "outside the ring" do
+        subject { linear_ring.intersects?(other_geometry) }
+
         let(:other_geometry) do
           OGR::Geometry.create_from_wkt("LINESTRING (100 100, 20 20)")
         end
 
-        subject { linear_ring.intersects?(other_geometry) }
-        it { is_expected.to eq false }
+        it { is_expected.to be false }
       end
 
       context "ends on a vertex" do
+        subject { linear_ring.intersects?(other_geometry) }
+
         let(:other_geometry) do
           OGR::Geometry.create_from_wkt("LINESTRING (50 50, 0 0)")
         end
 
-        subject { linear_ring.intersects?(other_geometry) }
-        it { is_expected.to eq false }
+        it { is_expected.to be false }
       end
 
       context "passes across the boundary" do
+        subject { linear_ring.intersects?(other_geometry) }
+
         let(:other_geometry) do
           OGR::Geometry.create_from_wkt("LINESTRING (15 5, 5 5)")
         end
 
-        subject { linear_ring.intersects?(other_geometry) }
-        it { is_expected.to eq false }
+        it { is_expected.to be false }
       end
     end
   end

--- a/spec/unit/ogr/geometries/multi_line_string_25d_spec.rb
+++ b/spec/unit/ogr/geometries/multi_line_string_25d_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe OGR::MultiLineString25D do
   describe "#type" do
     context "when created with data" do
       subject { OGR::Geometry.create_from_wkt(wkt) }
+
       let(:wkt) { "MULTILINESTRING((1 2 3, 2 2 3),(9 9 9, 10 10 10))" }
 
       it "returns :wkbMultiLineString25D" do

--- a/spec/unit/ogr/geometries/multi_point_25d_spec.rb
+++ b/spec/unit/ogr/geometries/multi_point_25d_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe OGR::MultiPoint25D do
   describe "#type" do
     context "when created with data" do
       subject { OGR::Geometry.create_from_wkt(wkt) }
+
       let(:wkt) { "MULTIPOINT((1 2 3),(2 2 3))" }
 
       it "returns :wkbPoint25D" do

--- a/spec/unit/ogr/geometries/multi_polygon_25d_spec.rb
+++ b/spec/unit/ogr/geometries/multi_polygon_25d_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe OGR::MultiPolygon25D do
   describe "#type" do
     context "when created with data" do
       subject { OGR::Geometry.create_from_wkt(wkt) }
+
       let(:wkt) { "MULTIPOLYGON(((0 0 1,0 1 1,1 1 1,0 0 1)),((0 0 5,1 1 5,1 0 5,0 0 5)))" }
 
       it "returns :wkbMultiPolygon25D" do

--- a/spec/unit/ogr/geometries/none_geometry_spec.rb
+++ b/spec/unit/ogr/geometries/none_geometry_spec.rb
@@ -8,6 +8,6 @@ RSpec.describe OGR::NoneGeometry do
   it "can be created from a pointer to a geometry" do
     geom_ptr = FFI::OGR::API.OGR_G_CreateGeometry(:wkbPoint)
     geom = described_class.new(geom_ptr)
-    expect(geom).to be_a OGR::NoneGeometry
+    expect(geom).to be_a described_class
   end
 end

--- a/spec/unit/ogr/geometries/point_25d_spec.rb
+++ b/spec/unit/ogr/geometries/point_25d_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe OGR::Point25D do
   describe "#type" do
     context "when created with data" do
       subject { OGR::Geometry.create_from_wkt(wkt) }
+
       let(:wkt) { "POINT(1 2 3)" }
 
       it "returns :wkbPoint25D" do

--- a/spec/unit/ogr/geometries/point_spec.rb
+++ b/spec/unit/ogr/geometries/point_spec.rb
@@ -4,6 +4,7 @@ require "ogr/geometry"
 
 RSpec.describe OGR::Point do
   subject { OGR::Geometry.create_from_wkt(wkt) }
+
   let(:wkt) { "POINT (1 2)" }
 
   let(:another_point) do
@@ -52,13 +53,13 @@ RSpec.describe OGR::Point do
     describe "#equals?" do
       context "a point with same coordinates" do
         it "returns true" do
-          expect(subject.equals?(same_point)).to eq true
+          expect(subject.equals?(same_point)).to be true
         end
       end
 
       context "a point with difference coordinates" do
         it "returns false" do
-          expect(subject.equals?(another_point)).to eq false
+          expect(subject.equals?(another_point)).to be false
         end
       end
     end
@@ -66,13 +67,13 @@ RSpec.describe OGR::Point do
     describe "#intersects?" do
       context "a point with same coordinates" do
         it "returns true" do
-          expect(subject.intersects?(same_point)).to eq true
+          expect(subject.intersects?(same_point)).to be true
         end
       end
 
       context "a point with difference coordinates" do
         it "returns false" do
-          expect(subject.intersects?(another_point)).to eq false
+          expect(subject.intersects?(another_point)).to be false
         end
       end
     end
@@ -80,13 +81,13 @@ RSpec.describe OGR::Point do
     describe "#disjoint?" do
       context "a point with same coordinates" do
         it "returns false" do
-          expect(subject.disjoint?(same_point)).to eq false
+          expect(subject.disjoint?(same_point)).to be false
         end
       end
 
       context "a point with difference coordinates" do
         it "returns true" do
-          expect(subject.disjoint?(another_point)).to eq true
+          expect(subject.disjoint?(another_point)).to be true
         end
       end
     end
@@ -95,13 +96,13 @@ RSpec.describe OGR::Point do
       context "a point with same coordinates" do
         # Not sure why this returns false...
         it "returns false" do
-          expect(subject.touches?(same_point)).to eq false
+          expect(subject.touches?(same_point)).to be false
         end
       end
 
       context "a point with difference coordinates" do
         it "returns false" do
-          expect(subject.touches?(another_point)).to eq false
+          expect(subject.touches?(another_point)).to be false
         end
       end
     end
@@ -109,13 +110,13 @@ RSpec.describe OGR::Point do
     describe "#crosses?" do
       context "a point with same coordinates" do
         it "returns false" do
-          expect(subject.crosses?(same_point)).to eq false
+          expect(subject.crosses?(same_point)).to be false
         end
       end
 
       context "a point with difference coordinates" do
         it "returns false" do
-          expect(subject.crosses?(another_point)).to eq false
+          expect(subject.crosses?(another_point)).to be false
         end
       end
     end
@@ -123,13 +124,13 @@ RSpec.describe OGR::Point do
     describe "#within?" do
       context "a point with same coordinates" do
         it "returns true" do
-          expect(subject.within?(same_point)).to eq true
+          expect(subject.within?(same_point)).to be true
         end
       end
 
       context "a point with difference coordinates" do
         it "returns false" do
-          expect(subject.within?(another_point)).to eq false
+          expect(subject.within?(another_point)).to be false
         end
       end
     end
@@ -137,13 +138,13 @@ RSpec.describe OGR::Point do
     describe "#contains?" do
       context "a point with same coordinates" do
         it "returns true" do
-          expect(subject.contains?(same_point)).to eq true
+          expect(subject.contains?(same_point)).to be true
         end
       end
 
       context "a point with difference coordinates" do
         it "returns false" do
-          expect(subject.contains?(another_point)).to eq false
+          expect(subject.contains?(another_point)).to be false
         end
       end
     end
@@ -151,38 +152,38 @@ RSpec.describe OGR::Point do
     describe "#overlaps?" do
       context "a point with same coordinates" do
         it "returns false" do
-          expect(subject.overlaps?(same_point)).to eq false
+          expect(subject.overlaps?(same_point)).to be false
         end
       end
 
       context "a point with difference coordinates" do
         it "returns false" do
-          expect(subject.overlaps?(another_point)).to eq false
+          expect(subject.overlaps?(another_point)).to be false
         end
       end
     end
 
     describe "#empty?" do
       it "returns false" do
-        expect(subject.empty?).to eq false
+        expect(subject.empty?).to be false
       end
     end
 
     describe "#valid?" do
       it "returns true" do
-        expect(subject.valid?).to eq true
+        expect(subject.valid?).to be true
       end
     end
 
     describe "#simple?" do
       it "returns true" do
-        expect(subject.simple?).to eq true
+        expect(subject.simple?).to be true
       end
     end
 
     describe "#ring?" do
       it "returns false" do
-        expect(subject.ring?).to eq false
+        expect(subject.ring?).to be false
       end
     end
 
@@ -212,21 +213,21 @@ RSpec.describe OGR::Point do
 
     describe "#set_point" do
       it "changes the x & y values" do
-        expect { subject.set_point(5, 6) }.to change { subject.point_value }
+        expect { subject.set_point(5, 6) }.to change(subject, :point_value)
           .from([1.0, 2.0]).to([5.0, 6.0])
       end
     end
 
     describe "#add_point" do
       it "changes the x & y values" do
-        expect { subject.add_point(5, 6) }.to change { subject.point_value }
+        expect { subject.add_point(5, 6) }.to change(subject, :point_value)
           .from([1.0, 2.0]).to([5.0, 6.0])
       end
     end
 
     describe "#empty!" do
       it "clears the point" do
-        expect { subject.empty! }.to change { subject.point_value }
+        expect { subject.empty! }.to change(subject, :point_value)
           .from([1.0, 2.0]).to([])
       end
     end
@@ -249,19 +250,19 @@ RSpec.describe OGR::Point do
 
     describe "#empty?" do
       it "returns true" do
-        expect(subject.empty?).to eq true
+        expect(subject.empty?).to be true
       end
     end
 
     describe "#valid?" do
       it "returns true" do
-        expect(subject.valid?).to eq true
+        expect(subject.valid?).to be true
       end
     end
 
     describe "#simple?" do
       it "returns true" do
-        expect(subject.simple?).to eq true
+        expect(subject.simple?).to be true
       end
     end
 
@@ -285,14 +286,14 @@ RSpec.describe OGR::Point do
 
     describe "#set_point" do
       it "changes the x & y values" do
-        expect { subject.set_point(5, 6) }.to change { subject.point_value }
+        expect { subject.set_point(5, 6) }.to change(subject, :point_value)
           .from([]).to([5.0, 6.0])
       end
     end
 
     describe "#add_point" do
       it "changes the x & y values" do
-        expect { subject.add_point(5, 6) }.to change { subject.point_value }
+        expect { subject.add_point(5, 6) }.to change(subject, :point_value)
           .from([]).to([5.0, 6.0])
       end
     end

--- a/spec/unit/ogr/geometries/polygon_25d_spec.rb
+++ b/spec/unit/ogr/geometries/polygon_25d_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe OGR::Polygon25D do
   describe "#type" do
     context "when created with data" do
       subject { OGR::Geometry.create_from_wkt(wkt) }
+
       let(:wkt) { "POLYGON((0 0 1,0 1 1,1 1 1,0 0 1))" }
 
       it "returns :wkbPolygon25D" do

--- a/spec/unit/ogr/geometries/polygon_spec.rb
+++ b/spec/unit/ogr/geometries/polygon_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe OGR::Polygon do
 
   describe "#to_multi_polygon" do
     subject(:polygon) { OGR::Geometry.create_from_wkt(wkt) }
+
     let(:wkt) { "POLYGON((10 10, 20 20, 30 30))" }
 
     it "returns a MultiPolygon" do

--- a/spec/unit/ogr/geometries/unknown_geometry_spec.rb
+++ b/spec/unit/ogr/geometries/unknown_geometry_spec.rb
@@ -6,6 +6,6 @@ RSpec.describe OGR::UnknownGeometry do
   it "can be created from a pointer to a geometry" do
     geom_ptr = FFI::OGR::API.OGR_G_CreateGeometry(:wkbPoint)
     geom = described_class.new(geom_ptr)
-    expect(geom).to be_a OGR::UnknownGeometry
+    expect(geom).to be_a described_class
   end
 end

--- a/spec/unit/ogr/geometry_field_definition_spec.rb
+++ b/spec/unit/ogr/geometry_field_definition_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe OGR::GeometryFieldDefinition do
   describe "#spatial_reference" do
     context "default" do
       subject { geometry_field_definition.spatial_reference }
+
       it { is_expected.to be_nil }
     end
   end
@@ -49,7 +50,7 @@ RSpec.describe OGR::GeometryFieldDefinition do
 
   describe "#ignored?" do
     context "default" do
-      it { is_expected.to_not be_ignored }
+      it { is_expected.not_to be_ignored }
     end
   end
 

--- a/spec/unit/ogr/geometry_spec.rb
+++ b/spec/unit/ogr/geometry_spec.rb
@@ -4,55 +4,65 @@ require "ogr/geometry"
 
 RSpec.describe OGR::Geometry do
   describe ".create_from_wkt" do
-    subject { OGR::Geometry.create_from_wkt(wkt) }
+    subject { described_class.create_from_wkt(wkt) }
 
     context "a 2D Point" do
       let(:wkt) { "POINT(1 32)" }
+
       it { is_expected.to be_a OGR::Point }
     end
 
     context "a 2.5D Point" do
       let(:wkt) { "POINT(1 32 100)" }
+
       it { is_expected.to be_a OGR::Point25D }
     end
 
     context "a 2D LineString" do
       let(:wkt) { "LINESTRING(3 19,12 20)" }
+
       it { is_expected.to be_a OGR::LineString }
     end
 
     context "a 2.5D LineString" do
       let(:wkt) { "LINESTRING(3 4 19,12 23 20)" }
+
       it { is_expected.to be_a OGR::LineString25D }
     end
 
     context "a 2D Polygon" do
       let(:wkt) { "POLYGON((1 1,2 2,3 3))" }
+
       it { is_expected.to be_a OGR::Polygon }
     end
 
     context "a 2.5D Polygon" do
       let(:wkt) { "POLYGON((1 1 1,2 2 2,3 3 3))" }
+
       it { is_expected.to be_a OGR::Polygon25D }
     end
 
     context "a 2D MultiPoint" do
       let(:wkt) { "MULTIPOINT((1 1),(2 2))" }
+
       it { is_expected.to be_a OGR::MultiPoint }
     end
 
     context "a 2.5D MultiPoint" do
       let(:wkt) { "MULTIPOINT((1 1 1),(2 2 2))" }
+
       it { is_expected.to be_a OGR::MultiPoint25D }
     end
 
     context "a 2D MultiLineString" do
       let(:wkt) { "MULTILINESTRING((3 4),(100 20))" }
+
       it { is_expected.to be_a OGR::MultiLineString }
     end
 
     context "a 2.5D MultiLineString" do
       let(:wkt) { "MULTILINESTRING((3 4 19),(100 20 40))" }
+
       it { is_expected.to be_a OGR::MultiLineString25D }
     end
 
@@ -74,7 +84,7 @@ RSpec.describe OGR::Geometry do
   end
 
   describe ".create_from_json" do
-    subject { OGR::Geometry.create_from_json(json) }
+    subject { described_class.create_from_json(json) }
 
     context "a 2D Point" do
       let(:json) do
@@ -260,7 +270,7 @@ RSpec.describe OGR::Geometry do
   end
 
   describe ".create_from_gml" do
-    subject { OGR::Geometry.create_from_gml(gml) }
+    subject { described_class.create_from_gml(gml) }
 
     context "a 2D Point" do
       let(:gml) do
@@ -490,17 +500,19 @@ RSpec.describe OGR::Geometry do
   end
 
   describe ".create_from_wkb" do
-    subject { OGR::Geometry.create_from_wkb(wkb) }
+    subject { described_class.create_from_wkb(wkb) }
 
     context "a 2D Point" do
       # POINT(1 32)
       let(:wkb) { ["0101000000000000000000f03f0000000000004040"].pack("H*") }
+
       it { is_expected.to be_a OGR::Point }
     end
 
     context "a 2.5D Point" do
       # POINT(1 32 100)
       let(:wkb) { ["01e9030000000000000000f03f00000000000040400000000000005940"].pack("H*") }
+
       it { is_expected.to be_a OGR::Point }
     end
 
@@ -509,6 +521,7 @@ RSpec.describe OGR::Geometry do
       let(:wkb) do
         ["0102000000020000000000000000000840000000000000334000000000000028400000000000003440"].pack("H*")
       end
+
       it { is_expected.to be_a OGR::LineString }
     end
 
@@ -544,6 +557,7 @@ RSpec.describe OGR::Geometry do
               "0000f03f000000000000f03f"
         [hex].pack("H*")
       end
+
       it { is_expected.to be_a OGR::Polygon25D }
     end
 
@@ -554,6 +568,7 @@ RSpec.describe OGR::Geometry do
               "01000000000000000000f03f000000000000f03f"
         [hex].pack("H*")
       end
+
       it { is_expected.to be_a OGR::MultiPoint }
     end
 
@@ -565,6 +580,7 @@ RSpec.describe OGR::Geometry do
               "00f03f"
         [hex].pack("H*")
       end
+
       it { is_expected.to be_a OGR::MultiPoint25D }
     end
 
@@ -577,6 +593,7 @@ RSpec.describe OGR::Geometry do
               "344000000000000034400000000000003e400000000000003e40"
         [hex].pack("H*")
       end
+
       it { is_expected.to be_a OGR::MultiLineString }
     end
 
@@ -590,6 +607,7 @@ RSpec.describe OGR::Geometry do
               "400000000000001c400000000000001c40"
         [hex].pack("H*")
       end
+
       it { is_expected.to be_a OGR::MultiLineString25D }
     end
 
@@ -627,58 +645,68 @@ RSpec.describe OGR::Geometry do
   describe ".type_to_name" do
     context "wkbUnknown" do
       subject { described_class.type_to_name(:wkbUnknown) }
+
       it { is_expected.to eq "Unknown (any)" }
     end
 
     context "wkbPoint" do
       subject { described_class.type_to_name(:wkbPoint) }
+
       it { is_expected.to eq "Point" }
     end
 
     context "wkbLineString" do
       subject { described_class.type_to_name(:wkbLineString) }
+
       it { is_expected.to eq "Line String" }
     end
 
     context "wkbPolygon" do
       subject { described_class.type_to_name(:wkbPolygon) }
+
       it { is_expected.to eq "Polygon" }
     end
 
     context "wkbMultiPoint" do
       subject { described_class.type_to_name(:wkbMultiPoint) }
+
       it { is_expected.to eq "Multi Point" }
     end
 
     context "wkbMultiLineString" do
       subject { described_class.type_to_name(:wkbMultiLineString) }
+
       it { is_expected.to eq "Multi Line String" }
     end
 
     context "wkbMultiPolygon" do
       subject { described_class.type_to_name(:wkbMultiPolygon) }
+
       it { is_expected.to eq "Multi Polygon" }
     end
 
     context "wkbGeometryCollection" do
       subject { described_class.type_to_name(:wkbGeometryCollection) }
+
       it { is_expected.to eq "Geometry Collection" }
     end
 
     context "wkbNone" do
       subject { described_class.type_to_name(:wkbNone) }
+
       it { is_expected.to eq "None" }
     end
 
     context "wkbLinearRing" do
       subject { described_class.type_to_name(:wkbLinearRing) }
+
       # Per GDAL docs, LinearRing is only used for geometry creation.
       it { is_expected.to eq "Unrecognized: 101" }
     end
   end
 
   describe "#to_geo_json_ex" do
-    subject { OGR::Geometry.create_from_wkt(wkt) }
+    subject { described_class.create_from_wkt(wkt) }
 
     let(:wkt) do
       "LINESTRING(100.01234567890123456789 100.01234567890123456789, " \
@@ -691,17 +719,17 @@ RSpec.describe OGR::Geometry do
       json1 = subject.to_geo_json_ex
       json2 = subject.to_geo_json_ex(coordinate_precision: "20")
 
-      g1 = OGR::Geometry.create_from_json(json1)
-      g2 = OGR::Geometry.create_from_json(json2)
+      g1 = described_class.create_from_json(json1)
+      g2 = described_class.create_from_json(json2)
 
       # these compare because they both use default precision
       expect(json1).to eq g1.to_geo_json_ex
 
       # these DON'T compare because the LHS has more precision than the RHS
-      expect(json2).to_not eq g2.to_geo_json_ex
+      expect(json2).not_to eq g2.to_geo_json_ex
 
       # these DON'T compare because the RHS has more precision than the LHS
-      expect(json1).to_not eq g1.to_geo_json_ex(coordinate_precision: "20")
+      expect(json1).not_to eq g1.to_geo_json_ex(coordinate_precision: "20")
 
       # these both compare because they both use extra precision
       expect(json2).to eq g2.to_geo_json_ex(coordinate_precision: "20")

--- a/spec/unit/ogr/internal_helpers_spec.rb
+++ b/spec/unit/ogr/internal_helpers_spec.rb
@@ -14,12 +14,14 @@ RSpec.describe OGR::InternalHelpers do
   describe "._boolean_access_flag" do
     context "when 'w'" do
       subject { tester._boolean_access_flag("w") }
-      it { is_expected.to eq true }
+
+      it { is_expected.to be true }
     end
 
     context "when 'r'" do
       subject { tester._boolean_access_flag("r") }
-      it { is_expected.to eq false }
+
+      it { is_expected.to be false }
     end
 
     context "when anything else" do
@@ -32,17 +34,20 @@ RSpec.describe OGR::InternalHelpers do
   describe "._format_time_zone_for_ruby" do
     context "time_zone is 0" do
       subject { tester._format_time_zone_for_ruby(0) }
+
       it { is_expected.to be_nil }
     end
 
     context "time_zone is 1" do
       subject { tester._format_time_zone_for_ruby(1) }
+
       it { is_expected.to be_a String }
-      it { is_expected.to_not be_empty }
+      it { is_expected.not_to be_empty }
     end
 
     context "time_zone is 100" do
       subject { tester._format_time_zone_for_ruby(100) }
+
       it { is_expected.to eq "+0" }
     end
   end
@@ -50,21 +55,25 @@ RSpec.describe OGR::InternalHelpers do
   describe "._format_time_zone_for_ogr" do
     context "GMT" do
       subject { tester._format_time_zone_for_ogr("GMT") }
+
       it { is_expected.to eq 100 }
     end
 
     context "+00:00" do
       subject { tester._format_time_zone_for_ogr("+00:00") }
+
       it { is_expected.to eq 100 }
     end
 
     context "not nil and not GMT" do
       subject { tester._format_time_zone_for_ogr("asdf") }
+
       it { is_expected.to eq 1 }
     end
 
     context "nil" do
       subject { tester._format_time_zone_for_ogr(nil) }
+
       it { is_expected.to eq 0 }
     end
   end

--- a/spec/unit/ogr/layer_mixins/ogr_feature_methods_spec.rb
+++ b/spec/unit/ogr/layer_mixins/ogr_feature_methods_spec.rb
@@ -112,8 +112,10 @@ RSpec.describe OGR::Layer do
     end
 
     context "has a feature" do
-      before { layer.create_feature(OGR::Feature.new(layer.feature_definition)) }
       subject { layer.next_feature }
+
+      before { layer.create_feature(OGR::Feature.new(layer.feature_definition)) }
+
       after { subject.destroy! }
 
       it "returns an OGR::Feature" do
@@ -131,6 +133,11 @@ RSpec.describe OGR::Layer do
     end
 
     context "features exist" do
+      subject do
+        layer.next_feature_index = 1
+        layer.next_feature
+      end
+
       let!(:feature1) do
         layer.create_feature(OGR::Feature.new(layer.feature_definition))
       end
@@ -139,15 +146,10 @@ RSpec.describe OGR::Layer do
         layer.create_feature(OGR::Feature.new(layer.feature_definition))
       end
 
-      subject do
-        layer.next_feature_index = 1
-        layer.next_feature
-      end
-
       after { subject.destroy! }
 
       it "sets to the given feature" do
-        expect(subject).to_not be_nil
+        expect(subject).not_to be_nil
       end
     end
   end

--- a/spec/unit/ogr/layer_mixins/ogr_field_methods_spec.rb
+++ b/spec/unit/ogr/layer_mixins/ogr_field_methods_spec.rb
@@ -125,13 +125,13 @@ RSpec.describe OGR::Layer do
     context "reordering is supported" do
       context "field does not exist at one of the given indexes" do
         it "returns false" do
-          expect(subject.reorder_fields(1, 0)).to eq false
+          expect(subject.reorder_fields(1, 0)).to be false
         end
       end
 
       context "no fields given" do
         it "returns false" do
-          expect(subject.reorder_fields).to eq false
+          expect(subject.reorder_fields).to be false
         end
       end
 
@@ -410,7 +410,7 @@ RSpec.describe OGR::Layer do
   describe "#set_ignored_fields" do
     context "no fields given" do
       it "returns false" do
-        expect(subject.set_ignored_fields).to eq false
+        expect(subject.set_ignored_fields).to be false
       end
     end
 

--- a/spec/unit/ogr/layer_mixins/ogr_query_filter_methods_spec.rb
+++ b/spec/unit/ogr/layer_mixins/ogr_query_filter_methods_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe OGR::Layer do
   describe "#spatial_filter" do
     context "default" do
       subject { layer.spatial_filter }
+
       it { is_expected.to be_nil }
     end
   end
@@ -23,21 +24,21 @@ RSpec.describe OGR::Layer do
   describe "#set_spatial_filter_ex" do
     it "does not die" do
       geometry = OGR::Geometry.create_from_wkt("POINT (1 1)")
-      expect { subject.set_spatial_filter_ex(0, geometry) }.to_not raise_exception
+      expect { subject.set_spatial_filter_ex(0, geometry) }.not_to raise_exception
     end
   end
 
   describe "#set_spatial_filter_rectangle" do
     it "does not die" do
       expect { subject.set_spatial_filter_rectangle(0, 0, 1000, 1000) }
-        .to_not raise_exception
+        .not_to raise_exception
     end
   end
 
   describe "#set_spatial_filter_rectangle_ex" do
     it "does not die" do
       expect { subject.set_spatial_filter_rectangle_ex(0, 0, 0, 1000, 1000) }
-        .to_not raise_exception
+        .not_to raise_exception
     end
   end
 end

--- a/spec/unit/ogr/layer_spec.rb
+++ b/spec/unit/ogr/layer_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe OGR::Layer do
 
   describe "#sync_to_disk" do
     it "does not die" do
-      expect { subject.sync_to_disk }.to_not raise_exception
+      expect { subject.sync_to_disk }.not_to raise_exception
     end
   end
 
@@ -32,14 +32,14 @@ RSpec.describe OGR::Layer do
       # I don't get why these return false...
       it "returns false" do
         capabilities.each do |capability|
-          expect(subject.test_capability(capability)).to eq false
+          expect(subject.test_capability(capability)).to be false
         end
       end
     end
 
     context "unsupported capabilities to check" do
       it "returns false" do
-        expect(subject.test_capability("meow")).to eq false
+        expect(subject.test_capability("meow")).to be false
       end
     end
   end

--- a/spec/unit/ogr/spatial_reference_mixins/coordinate_system_getter_setters_spec.rb
+++ b/spec/unit/ogr/spatial_reference_mixins/coordinate_system_getter_setters_spec.rb
@@ -3,8 +3,9 @@
 require "ogr/spatial_reference"
 
 RSpec.describe OGR::SpatialReference do
-  subject(:wgs84) { OGR::SpatialReference.new.import_from_epsg(3857) }
-  let(:empty_subject) { OGR::SpatialReference.new }
+  subject(:wgs84) { described_class.new.import_from_epsg(3857) }
+
+  let(:empty_subject) { described_class.new }
 
   describe "#set_local_cs" do
     it "sets the LOCAL_CS" do
@@ -46,7 +47,7 @@ RSpec.describe OGR::SpatialReference do
 
   describe "#set_towgs84 + #towgs84" do
     subject do
-      s = OGR::SpatialReference.new.import_from_epsg(4326)
+      s = described_class.new.import_from_epsg(4326)
       s.set_towgs84(x_distance: 10, y_distance: 10, x_rotation: 1235.4, scaling_factor: 3)
       s
     end
@@ -70,7 +71,7 @@ RSpec.describe OGR::SpatialReference do
 
   describe "#set_projection" do
     it "doesn't blow up" do
-      subject.set_projection "Transverse_Mercator"
+      expect { subject.set_projection "Transverse_Mercator" }.not_to raise_error
     end
   end
 

--- a/spec/unit/ogr/spatial_reference_mixins/exporters_spec.rb
+++ b/spec/unit/ogr/spatial_reference_mixins/exporters_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe OGR::SpatialReference do
 
       it "returns a PROJ4 String" do
         expected_proj4 =
-          if GDAL.version_num >= "3000100" && OGR::SpatialReference.proj_version.major > 6
+          if GDAL.version_num >= "3000100" && described_class.proj_version.major > 6
             # Returns official PROJ4 string for EPSG:4322 (https://epsg.io/4322).
             "+proj=longlat +ellps=WGS72 +no_defs"
           else

--- a/spec/unit/ogr/spatial_reference_mixins/importers_spec.rb
+++ b/spec/unit/ogr/spatial_reference_mixins/importers_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe OGR::SpatialReference do
         if GDAL.version_num < "3000000"
           # NOTE: Looks like it should be `true`, as in GDAL 3.
           # By some reason GDAL 2 returns `false`.
-          expect(subject.epsg_treats_as_lat_long?).to eq false
+          expect(subject.epsg_treats_as_lat_long?).to be false
         else
-          expect(subject.epsg_treats_as_lat_long?).to eq true
+          expect(subject.epsg_treats_as_lat_long?).to be true
         end
       end
     end
@@ -63,7 +63,7 @@ RSpec.describe OGR::SpatialReference do
 
     it "treats 4326 as lat/lon" do
       subject.import_from_epsga(4326)
-      expect(subject.epsg_treats_as_lat_long?).to eq true
+      expect(subject.epsg_treats_as_lat_long?).to be true
     end
   end
 end

--- a/spec/unit/ogr/spatial_reference_mixins/morphers_spec.rb
+++ b/spec/unit/ogr/spatial_reference_mixins/morphers_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe OGR::SpatialReference do
   end
 
   describe "#morph_from_esri!" do
+    subject { described_class.new.import_from_esri(esri) }
+
     let(:esri) do
       <<-ESRI.strip
         GEOGCS["GCS_North_American_1983",
@@ -23,8 +25,6 @@ RSpec.describe OGR::SpatialReference do
            UNIT["Degree",0.0174532925199433]]
       ESRI
     end
-
-    subject { described_class.new.import_from_esri(esri) }
 
     it "changes the SRS to ESRI" do
       pending "Figure out why morphing does not change anything"

--- a/spec/unit/ogr/spatial_reference_mixins/parameter_getter_setters_spec.rb
+++ b/spec/unit/ogr/spatial_reference_mixins/parameter_getter_setters_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe OGR::SpatialReference do
   # Not sure why yet, but it seems I can only do angular unit setting with
   # certain projections; 4326 is one of them.
   describe "#set_angular_units + #angular_units" do
-    subject { OGR::SpatialReference.new.import_from_epsg(4326) }
+    subject { described_class.new.import_from_epsg(4326) }
 
     context "using a known label and value" do
       it "sets the new label and value" do
@@ -26,7 +26,7 @@ RSpec.describe OGR::SpatialReference do
   # Not sure why yet, but it seems I can only do linear unit setting with
   # certain projections; 4333 is one of them.
   describe "#set_linear_units + #linear_units" do
-    subject { OGR::SpatialReference.new.import_from_epsg(4333) }
+    subject { described_class.new.import_from_epsg(4333) }
 
     context "using a known label and value" do
       it "sets the new label and value" do
@@ -46,7 +46,7 @@ RSpec.describe OGR::SpatialReference do
   # Not sure why yet, but it seems I can only do linear unit setting with
   # certain projections; 4333 is one of them.
   describe "#set_linear_units_and_update_parameters + #linear_units" do
-    subject { OGR::SpatialReference.new.import_from_epsg(4333) }
+    subject { described_class.new.import_from_epsg(4333) }
 
     context "using a known label and value" do
       it "sets the new label and value" do

--- a/spec/unit/ogr/spatial_reference_mixins/type_checks_spec.rb
+++ b/spec/unit/ogr/spatial_reference_mixins/type_checks_spec.rb
@@ -6,11 +6,12 @@ RSpec.describe OGR::SpatialReference do
   describe "#geographic?" do
     context "root is a GEOGCS node" do
       subject { described_class.new.import_from_epsg 4326 }
+
       it { is_expected.to be_geographic }
     end
 
     context "root is not a GEOGCS node" do
-      it { is_expected.to_not be_geographic }
+      it { is_expected.not_to be_geographic }
     end
   end
 
@@ -26,7 +27,7 @@ RSpec.describe OGR::SpatialReference do
     end
 
     context "root is not a LOCAL_CS node" do
-      it { is_expected.to_not be_local }
+      it { is_expected.not_to be_local }
     end
   end
 
@@ -42,7 +43,7 @@ RSpec.describe OGR::SpatialReference do
     end
 
     context "does not contain a PROJCS node" do
-      it { is_expected.to_not be_projected }
+      it { is_expected.not_to be_projected }
     end
   end
 
@@ -58,7 +59,7 @@ RSpec.describe OGR::SpatialReference do
     end
 
     context "does not contain a COMPD_CS node" do
-      it { is_expected.to_not be_compound }
+      it { is_expected.not_to be_compound }
     end
   end
 
@@ -74,7 +75,7 @@ RSpec.describe OGR::SpatialReference do
     end
 
     context "does not contain a GEOCCS node" do
-      it { is_expected.to_not be_geocentric }
+      it { is_expected.not_to be_geocentric }
     end
   end
 
@@ -90,35 +91,43 @@ RSpec.describe OGR::SpatialReference do
     end
 
     context "does not contain a VERT_CS node" do
-      it { is_expected.to_not be_vertical }
+      it { is_expected.not_to be_vertical }
     end
   end
 
   describe "#same?" do
     context "SpatialReferences describe the same system" do
       subject { described_class.new.import_from_epsg(4322) }
+
       let(:other) { described_class.new.import_from_epsg(4322) }
-      it("returns true") { expect(subject.same?(other)).to eq true }
+
+      it("returns true") { expect(subject.same?(other)).to be true }
     end
 
     context "SpatialReferences describe different systems" do
       subject { described_class.new.import_from_epsg(4322) }
+
       let(:other) { described_class.new.import_from_epsg(4326) }
-      it("returns false") { expect(subject.same?(other)).to eq false }
+
+      it("returns false") { expect(subject.same?(other)).to be false }
     end
   end
 
   describe "#geog_cs_is_same?" do
     context "SpatialReferences describe the same GEOGCS system" do
       subject { described_class.new.import_from_epsg(4322) }
+
       let(:other) { described_class.new.import_from_epsg(4322) }
-      it("returns true") { expect(subject.geog_cs_is_same?(other)).to eq true }
+
+      it("returns true") { expect(subject.geog_cs_is_same?(other)).to be true }
     end
 
     context "SpatialReferences describe different systems" do
       subject { described_class.new.import_from_epsg(4322) }
+
       let(:other) { described_class.new.import_from_epsg(4326) }
-      it("returns false") { expect(subject.geog_cs_is_same?(other)).to eq false }
+
+      it("returns false") { expect(subject.geog_cs_is_same?(other)).to be false }
     end
   end
 
@@ -136,7 +145,7 @@ RSpec.describe OGR::SpatialReference do
         sr
       end
 
-      it("returns true") { expect(subject.vert_cs_is_same?(other)).to eq true }
+      it("returns true") { expect(subject.vert_cs_is_same?(other)).to be true }
     end
 
     context "SpatialReferences describe different systems" do
@@ -152,7 +161,7 @@ RSpec.describe OGR::SpatialReference do
         sr
       end
 
-      it("returns false") { expect(subject.vert_cs_is_same?(other)).to eq false }
+      it("returns false") { expect(subject.vert_cs_is_same?(other)).to be false }
     end
   end
 end

--- a/spec/unit/ogr/spatial_reference_spec.rb
+++ b/spec/unit/ogr/spatial_reference_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe OGR::SpatialReference do
   end
 
   describe "#copy_geog_cs_from" do
-    let(:other_srs) { OGR::SpatialReference.new.import_from_epsg(4326) }
+    let(:other_srs) { described_class.new.import_from_epsg(4326) }
 
     it "copies the info over" do
       subject.copy_geog_cs_from(other_srs)

--- a/spec/unit/ogr/style_table_spec.rb
+++ b/spec/unit/ogr/style_table_spec.rb
@@ -5,11 +5,9 @@ require "ogr/style_table"
 RSpec.describe OGR::StyleTable do
   describe "#add_style + #find" do
     it "#add_style returns true" do
-      expect(subject.add_style("test style", "#ffffff")).to eq true
+      expect(subject.add_style("test style", "#ffffff")).to be true
     end
-  end
 
-  describe "#add_style + #find" do
     it "adds the style to the table" do
       subject.add_style("test style", "#ffffff")
       expect(subject.find("test style")).to eq "#ffffff"
@@ -55,7 +53,7 @@ RSpec.describe OGR::StyleTable do
       end
 
       it "returns true and imports the styles from the file" do
-        expect(subject.load!(file_path)).to eq true
+        expect(subject.load!(file_path)).to be true
         expect(subject.find("meow things")).to eq "Meow"
       end
     end

--- a/spec/unit/ogr/style_tool_spec.rb
+++ b/spec/unit/ogr/style_tool_spec.rb
@@ -3,6 +3,8 @@
 require "ogr/style_tool"
 
 RSpec.describe OGR::StyleTool do
+  subject(:pen_tool) { described_class.new(:OGRSTCPen) }
+
   describe "#initialize" do
     context "with supported classes" do
       let(:supported_classes) do
@@ -13,7 +15,7 @@ RSpec.describe OGR::StyleTool do
         supported_classes.each do |supported_class|
           expect do
             described_class.new(supported_class)
-          end.to_not raise_exception
+          end.not_to raise_exception
         end
       end
     end
@@ -33,11 +35,10 @@ RSpec.describe OGR::StyleTool do
     end
   end
 
-  subject(:pen_tool) { described_class.new(:OGRSTCPen) }
-
   describe "#style_string" do
     context "default style string" do
       subject { pen_tool.style_string }
+
       it { is_expected.to be_nil }
     end
   end
@@ -51,6 +52,7 @@ RSpec.describe OGR::StyleTool do
   describe "#unit" do
     context "default unit" do
       subject { pen_tool.unit }
+
       it { is_expected.to eq :OGRSTUMM }
     end
   end

--- a/spec/unit/version_info_spec.rb
+++ b/spec/unit/version_info_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe GDAL::VersionInfo do
   describe "#version_num" do
     it "returns a non-empty String" do
       expect(subject.version_num).to be_a String
-      expect(subject.version_num).to_not be_empty
+      expect(subject.version_num).not_to be_empty
     end
   end
 
@@ -23,14 +23,14 @@ RSpec.describe GDAL::VersionInfo do
   describe "#release_name" do
     it "returns a non-empty String" do
       expect(subject.release_name).to be_a String
-      expect(subject.release_name).to_not be_empty
+      expect(subject.release_name).not_to be_empty
     end
   end
 
   describe "#license" do
     it "returns a non-empty String" do
       expect(subject.license).to be_a String
-      expect(subject.license).to_not be_empty
+      expect(subject.license).not_to be_empty
     end
   end
 
@@ -43,7 +43,7 @@ RSpec.describe GDAL::VersionInfo do
   describe "#long_version" do
     it "returns a non-empty String" do
       expect(subject.long_version).to be_a String
-      expect(subject.long_version).to_not be_empty
+      expect(subject.long_version).not_to be_empty
     end
   end
 end


### PR DESCRIPTION
## What & why

Catches the RuboCop toolchain up to current versions. RuboCop and `rubocop-performance` had been deliberately pinned old (`rubocop <= 1.63.1`) to defer ~200 untriaged offenses; this un-defers that. Supersedes #139 (the Dependabot bump that failed CI because of the fallout).

This is **PR A** — the mechanical/config half. It deliberately **keeps `.rubocop_todo.yml`** so the `Metrics/*` cops stay suppressed and CI stays green. A follow-up **PR B** replaces the machine-generated todo with intentional `Metrics/*` limits and refactors the genuine outliers.

## Changes

**Tooling (`c97a14b`)**
- Bump `rubocop` → 1.88.2, `rubocop-performance` → 1.26.1; add `rubocop-rspec` 3.10.2 + `rubocop-rake` 0.7.1.
- Exact `=` pins (Gemfile.lock is gitignored per gem convention, so pins are what keep CI reproducible; upgrades are deliberate pin bumps).
- Migrate `.rubocop.yml` `require:` → `plugins:` for the three plugin extensions.

**Mechanical library cleanup (`2338d96`)**
- Safe autocorrects (`EmptyLinesAfterModuleInclusion`, `SuperArguments`, `RedundantCopDisableDirective`, …).
- Reviewed unsafe autocorrects (`Lint/AmbiguousRange`, `Style/ComparableBetween`, `Style/PredicateWithKind`) + a manual `Lint/Void` dead-code removal in `OGR::DataSource#style_table=`.
- Documented inline `# rubocop:disable` for public-API predicate methods (`Naming/PredicateMethod`, `Naming/PredicatePrefix`) — **no renames** (would be breaking); fixed a stale `Naming/PredicateName` directive (cop was renamed to `PredicatePrefix`).
- `Style/OneClassPerFile` excluded for the 3 core-ext files that legitimately reopen classes.

**rubocop-rspec/rake triage (`5ab466e`)**
- 18 opinionated rubocop-rspec cops disabled with rationale (mature 130-file suite predates the plugin); the 5 threshold cops carry a `# TODO(PR B)` note to revisit as configured limits.
- Safe + reviewed-unsafe rspec/rake autocorrects; ~14 genuine hand-fixes.
- **Fixed 2 latent test bugs** surfaced by the new cops: a misspelled `instance_double "OGR::SpatialRefernce"` string double (now a real verifying double), and a broken `be_in` matcher.

## Verification
- `bundle exec rubocop --parallel` → **0 offenses / 378 files**.
- Unit specs → **1539 examples, 0 failures, 395 pending** (unchanged from baseline).
- Integration specs → **217 / 0 failures** before and after (fixed seed; the suite has an unrelated Ruby-4.0/Ractor flake tracked separately).

## Follow-ups filed (out of scope, not fixed here)
- `Dockerfile.gdal3` build failure (`gem update --system`).
- `spec_helper.rb` SimpleCov `add_filter`/`add_group` deprecations (simplecov 1.0).
- `GDAL::RasterAttributeTable` has no unit coverage.
- Ruby-4.0 / Ractor / `log_switch` cvar-cache VM-crash flake in the integration suite.
- `GDAL::RasterBand#checksum_image` returns a boolean but its YARD says `@return [Integer]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
