### PR TITLE
fix(raster_band): stitch tiled blocks so to_na returns correct dimensions

### DIFF
--- a/lib/gdal/extensions/raster_band/extensions.rb
+++ b/lib/gdal/extensions/raster_band/extensions.rb
@@ -23,7 +23,7 @@ module GDAL
 
       # @return [Array]
       def to_a
-        read_lines_by_block.to_a
+        readlines.to_a
       end
 
       # Iterates through all lines and builds an NArray of pixels.

--- a/lib/gdal/extensions/raster_band/io_extensions.rb
+++ b/lib/gdal/extensions/raster_band/io_extensions.rb
@@ -87,8 +87,11 @@ module GDAL
         block_size[:x] * block_size[:y]
       end
 
-      # Reads through the raster, block-by-block then line-by-line and yields
-      # the pixel data that it gathered.
+      # Reads through the raster block-by-block, stitching together the
+      # horizontally-adjacent blocks in each block-row so that it yields full
+      # raster lines. For striped rasters (a single block across the width) each
+      # block is yielded as soon as it is read; for tiled rasters one row of
+      # blocks is buffered before its lines are concatenated and yielded.
       #
       # @yieldparam row [Array<Number>] The Array of pixels for the current
       #   line.
@@ -98,11 +101,15 @@ module GDAL
       def read_lines_by_block
         return enum_for(:read_lines_by_block) unless block_given?
 
+        buffered = []
+
         read_blocks_by_block do |pixels, x_block_size, y_block_size|
-          pixels.each_slice(block_size[:x]).with_index do |row, block_row_number|
-            yield row.take(x_block_size)
-            break if block_row_number == y_block_size - 1
-          end
+          rows = pixels.each_slice(block_size[:x]).first(y_block_size).map { |row| row.first(x_block_size) }
+          buffered << rows
+          next unless buffered.size == block_count[:x]
+
+          y_block_size.times { |line| yield buffered.flat_map { |block_rows| block_rows[line] } }
+          buffered = []
         end
       end
 

--- a/spec/integration/gdal/extensions/raster_band/tiled_io_spec.rb
+++ b/spec/integration/gdal/extensions/raster_band/tiled_io_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "ffi-gdal"
+require "gdal"
+require "gdal/extensions/all"
+
+RSpec.describe "Tiled RasterBand IO extensions", type: :integration do
+  subject(:raster_band) { dataset.raster_band(1) }
+
+  # 380 wide x 765 tall, tiled 128x128, so block_count[:x] == 3.
+  let(:tiled_tiff) do
+    path = "../../../../../spec/support/images/osgeo/geotiff/zi_imaging/image0.tif"
+    File.expand_path(path, __dir__)
+  end
+
+  let(:dataset) { GDAL::Dataset.open(tiled_tiff, "r") }
+
+  # Canonical full-band read in row-major order, used to verify pixel ordering
+  # (not just shape) against the block-stitching implementation.
+  let(:reference) do
+    pointer = raster_band.raster_io("r")
+    pixel_count = raster_band.x_size * raster_band.y_size
+    GDAL._read_pointer(pointer, raster_band.data_type, pixel_count).each_slice(raster_band.x_size).to_a
+  end
+
+  after { dataset.close }
+
+  it "reads a tiled band with more than one x-block" do
+    expect(raster_band.block_count[:x]).to be > 1
+  end
+
+  describe "#to_na" do
+    it "returns an NArray whose shape matches the band's x/y sizes" do
+      expect(raster_band.to_na.shape).to eq([380, 765])
+    end
+
+    it "orders pixels the same as a canonical full-band read" do
+      expect(raster_band.to_na).to eq(NArray.to_na(reference))
+    end
+  end
+
+  describe "#read_lines_by_block" do
+    it "yields one full-width row per raster line" do
+      lines = raster_band.read_lines_by_block.to_a
+
+      expect(lines.size).to eq(765)
+      expect(lines.map(&:size).uniq).to eq([380])
+    end
+
+    it "stitches x-blocks into rows matching a canonical full-band read" do
+      expect(raster_band.read_lines_by_block.to_a).to eq(reference)
+    end
+  end
+end

--- a/spec/integration/gdal/extensions/raster_band/tiled_io_spec.rb
+++ b/spec/integration/gdal/extensions/raster_band/tiled_io_spec.rb
@@ -25,13 +25,17 @@ RSpec.describe "Tiled RasterBand IO extensions", type: :integration do
 
   after { dataset.close }
 
-  it "reads a tiled band with more than one x-block" do
+  # The fixture must be tiled (more than one x-block) AND non-square for these
+  # examples to catch the bug: a single-x-block raster hides the stitching
+  # defect, and a square raster hides an x/y-axis swap.
+  it "reads a tiled, non-square band" do
     expect(raster_band.block_count[:x]).to be > 1
+    expect(raster_band.x_size).not_to eq(raster_band.y_size)
   end
 
   describe "#to_na" do
     it "returns an NArray whose shape matches the band's x/y sizes" do
-      expect(raster_band.to_na.shape).to eq([380, 765])
+      expect(raster_band.to_na.shape).to eq([raster_band.x_size, raster_band.y_size])
     end
 
     it "orders pixels the same as a canonical full-band read" do
@@ -43,8 +47,8 @@ RSpec.describe "Tiled RasterBand IO extensions", type: :integration do
     it "yields one full-width row per raster line" do
       lines = raster_band.read_lines_by_block.to_a
 
-      expect(lines.size).to eq(765)
-      expect(lines.map(&:size).uniq).to eq([380])
+      expect(lines.size).to eq(raster_band.y_size)
+      expect(lines.map(&:size).uniq).to eq([raster_band.x_size])
     end
 
     it "stitches x-blocks into rows matching a canonical full-band read" do


### PR DESCRIPTION
## Summary

Fixes #4 — `GDAL::RasterBand#to_na` returned an `NArray` whose dimensions didn't match the band's x/y sizes for **tiled** rasters.

`to_na`/`to_nna`/`to_a` (and `Dataset#to_na`) all funnel through `to_a`, which read the band via `read_lines_by_block`. That method treated each tile's internal rows as full raster lines and **never stitched horizontally-adjacent x-blocks** back into a full-width row. It was only correct when there was a single block across the width (`block_count[:x] == 1`, i.e. striped rasters). For tiled rasters it emitted `block_count[:x] × y_size` short rows of width `block_size[:x]`, so both dimensions and pixel ordering were wrong.

**Repro (fixture `image0.tif`, 380×765, tiled 128×128):** `to_na.shape` was `[128, 2295]` (= `y_size × block_count[:x]`, width collapsed to `block_size[:x]`) instead of `[380, 765]`.

## Changes

- `lib/gdal/extensions/raster_band/extensions.rb` — `to_a` now reads full-width scanlines via `readlines` (unaffected by tiling; matches the existing "iterates through all lines" docstring).
- `lib/gdal/extensions/raster_band/io_extensions.rb` — `read_lines_by_block` rewritten to buffer one row of x-blocks (`block_count[:x]` blocks) and concatenate matching line-slices before yielding, so it yields full raster lines for tiled and striped rasters alike.
- `spec/integration/gdal/extensions/raster_band/tiled_io_spec.rb` — new integration spec against the tiled `image0.tif` fixture, asserting shape **and** pixel ordering (both `to_na` and `read_lines_by_block` compared for exact equality against a canonical full-band `raster_io` read).

## Compatibility

Not a breaking change. No public method signature or return type changes. **Striped-raster output is byte-identical to before** (verified); output changes only for tiled rasters, from incorrect to correct.

## Verification

- Unit: `spec/unit/gdal/extensions/raster_band/` → 28 examples, 0 failures (existing striped specs unchanged).
- Integration: new `tiled_io_spec.rb` → 5 examples, 0 failures; broad `spec/integration/gdal` → 204 / 0 / 9 pending (no `Dataset#to_na` / classifier regressions).
- Lint: `rubocop --parallel` → no offenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)