### PR TITLE
test(gdal): pin Dataset#to_na NArray behavior

### DIFF
--- a/lib/gdal/extensions/dataset/extensions.rb
+++ b/lib/gdal/extensions/dataset/extensions.rb
@@ -190,18 +190,50 @@ module GDAL
         @raster_geometry.contains? source_geometry
       end
 
-      # Retrieves pixels from each raster band and converts this to an array of
-      # points per pixel.  For example:
+      # Retrieves pixels from each raster band and stacks them into a single
+      # NArray indexed as [y, x, band], so result[y, x, true] reads one
+      # pixel's band values -- the "points per pixel" intent this method was
+      # written for holds at the index level. The nested (#to_a)
+      # representation, however, is band-major with x/y swapped:
+      # [band][x][y]. For example:
       #
-      #   # If the arrays for each band look like:
-      #   red_band_array = [0, 0, 0]
-      #   green_band_array = [10, 10, 10]
-      #   blue_band_array = [99, 99, 99]
-      #   alpha_band_array = [250, 150, 2]
+      #   # If the ([row][pixel]) arrays for each band look like:
+      #   red_band_array = [
+      #     [0, 1, 2],
+      #     [3, 4, 5]
+      #   ]
+      #   green_band_array = [
+      #     [10, 11, 12],
+      #     [13, 14, 15]
+      #   ]
+      #   blue_band_array = [
+      #     [20, 21, 22],
+      #     [23, 24, 25]
+      #   ]
       #
-      #   # This array would look like:
-      #   [[0, 10, 99, 2], [0, 10, 99, 150], [0, 10, 99, 250]]
-      # @return NArray
+      #   # This array would look like ([band][pixel][row]):
+      #   [
+      #     [
+      #       [0, 3],
+      #       [1, 4],
+      #       [2, 5]
+      #     ],
+      #     [
+      #       [10, 13],
+      #       [11, 14],
+      #       [12, 15]
+      #     ],
+      #     [
+      #       [20, 23],
+      #       [21, 24],
+      #       [22, 25]
+      #     ]
+      #   ]
+      #
+      # Note the NMatrix intermediate widens the type: byte bands come back as
+      # int, and a :GDT_Float32 conversion comes back as double.
+      #
+      # @return [NArray]
       def to_na(to_data_type = nil)
         na = NMatrix.to_na(raster_bands.map { |r| r.to_na(to_data_type) })
 

--- a/spec/unit/gdal/extensions/dataset/extensions_spec.rb
+++ b/spec/unit/gdal/extensions/dataset/extensions_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require "gdal/driver"
+require "gdal/extensions/dataset/extensions"
+require "gdal/extensions/raster_band/extensions"
+require "gdal/extensions/raster_band/io_extensions"
+
+RSpec.describe "GDAL::Dataset::Extensions" do
+  let(:driver) { GDAL::Driver.by_name("MEM") }
+  let(:dataset) { driver.create_dataset("test", 3, 2, band_count: 3, data_type: :GDT_Byte) }
+
+  # Three 3x2 bands; pixel (x, y) of band i holds (y * 3 + x) + (i * 100), so
+  # every band/x/y combination is distinguishable in the stacked result.
+  let(:band_values) do
+    [
+      [
+        [0, 1, 2],
+        [3, 4, 5]
+      ],
+      [
+        [100, 101, 102],
+        [103, 104, 105]
+      ],
+      [
+        [200, 201, 202],
+        [203, 204, 205]
+      ]
+    ]
+  end
+
+  before do
+    dataset.raster_bands.each_with_index do |band, i|
+      band.write_xy_narray(band_values.fetch(i))
+    end
+  end
+
+  describe "#to_na" do
+    context "no conversion" do
+      subject(:result) { dataset.to_na }
+
+      # The nested representation is band-major with x/y swapped relative to
+      # the band rows written above: result.to_a is [band][x][y], NOT the
+      # per-pixel band-value tuples the previous doc example claimed.
+      it "stacks bands into a [band][x][y]-nested NArray" do
+        expect(result).to eq(
+          NArray[
+            [
+              [0, 3],
+              [1, 4],
+              [2, 5]
+            ],
+            [
+              [100, 103],
+              [101, 104],
+              [102, 105]
+            ],
+            [
+              [200, 203],
+              [201, 204],
+              [202, 205]
+            ]
+          ]
+        )
+      end
+
+      it "is indexed as [y, x, band]" do
+        expect(result.shape).to eq([2, 3, 3])
+        expect(result[0, 1, 1]).to eq(101)
+        expect(result[1, 2, 2]).to eq(205)
+      end
+
+      it "reads one pixel's band values as result[y, x, true]" do
+        expect(result[0, 1, true].to_a).to eq([1, 101, 201])
+        expect(result[1, 2, true].to_a).to eq([5, 105, 205])
+      end
+
+      # Relative to the written band data ([band][row][pixel]), the nested
+      # representation keeps the band-major grouping but transposes each
+      # band's rows and pixels.
+      it "nests #to_a as the written bands with rows and pixels transposed" do
+        expect(result.to_a).to eq(
+          [
+            [
+              [0, 3],
+              [1, 4],
+              [2, 5]
+            ],
+            [
+              [100, 103],
+              [101, 104],
+              [102, 105]
+            ],
+            [
+              [200, 203],
+              [201, 204],
+              [202, 205]
+            ]
+          ]
+        )
+      end
+
+      it "upcasts byte bands to int through the NMatrix intermediate" do
+        expect(result.typecode).to eq(NArray::INT)
+      end
+    end
+
+    context "convert to Float32" do
+      subject(:result) { dataset.to_na(:GDT_Float32) }
+
+      it "converts each band before stacking" do
+        expect(result).to eq(
+          NArray[
+            [
+              [0.0, 3.0],
+              [1.0, 4.0],
+              [2.0, 5.0]
+            ],
+            [
+              [100.0, 103.0],
+              [101.0, 104.0],
+              [102.0, 105.0]
+            ],
+            [
+              [200.0, 203.0],
+              [201.0, 204.0],
+              [202.0, 205.0]
+            ]
+          ]
+        )
+      end
+
+      # GDT_Float32 maps to NArray::FLOAT, which narray aliases to DFLOAT, so a
+      # single-precision request comes back double-precision.
+      it "widens the requested Float32 to double" do
+        expect(result.typecode).to eq(NArray::DFLOAT)
+      end
+    end
+  end
+end

--- a/spec/unit/gdal/extensions/raster_band/extensions_spec.rb
+++ b/spec/unit/gdal/extensions/raster_band/extensions_spec.rb
@@ -9,6 +9,15 @@ RSpec.describe "GDAL::RasterBand::Extensions" do
   let(:driver) { GDAL::Driver.by_name("MEM") }
   let(:dataset_byte) { driver.create_dataset("test", 15, 25, data_type: :GDT_Byte) }
 
+  let(:values_dataset) { driver.create_dataset("values_test", 3, 2, data_type: :GDT_Byte) }
+  let(:values_band) { values_dataset.raster_band(1) }
+  let(:band_rows) do
+    [
+      [0, 1, 2],
+      [3, 4, 5]
+    ]
+  end
+
   describe "#to_a" do
     subject { raster_band.to_a }
 
@@ -80,6 +89,167 @@ RSpec.describe "GDAL::RasterBand::Extensions" do
       subject { raster_band.to_na(:GDT_CFloat64) }
 
       it { is_expected.to eq(NArray.complex(15, 25)) }
+    end
+
+    context "with distinct pixel values" do
+      subject(:result) { values_band.to_na }
+
+      before { values_band.write_xy_narray(band_rows) }
+
+      it "returns an NArray shaped [x, y]" do
+        expect(result).to eq(
+          NArray[
+            [0, 1, 2],
+            [3, 4, 5]
+          ]
+        )
+      end
+
+      it "is indexed as [x, y]" do
+        expect(result.shape).to eq([3, 2])
+        expect(result[1, 0]).to eq(1)
+        expect(result[2, 1]).to eq(5)
+      end
+
+      it "nests #to_a as the written rows" do
+        expect(result.to_a).to eq(
+          [
+            [0, 1, 2],
+            [3, 4, 5]
+          ]
+        )
+      end
+
+      # NArray.to_na infers the type from the Ruby integers rather than from
+      # the band's data type, so even without a conversion a byte band comes
+      # back as int.
+      it "returns int for a byte band" do
+        expect(result.typecode).to eq(NArray::INT)
+      end
+    end
+  end
+
+  describe "#to_nna" do
+    subject(:result) { raster_band.to_nna }
+
+    it "returns a Numo array shaped [y, x]" do
+      expect(result).to eq(Numo::Int32.zeros(25, 15))
+    end
+
+    # Numo::NArray[*rows] infers the element type from the Ruby integers
+    # rather than from the band's data type, so a byte band comes back Int32.
+    # (Numo's == compares values across types, so the class needs its own
+    # assertion.)
+    it "infers Int32 for a byte band" do
+      expect(result.class).to eq(Numo::Int32)
+    end
+
+    context "with distinct pixel values" do
+      subject(:result) { values_band.to_nna }
+
+      before { values_band.write_xy_narray(band_rows) }
+
+      it "returns a Numo::NArray shaped [y, x]" do
+        expect(result).to eq(
+          Numo::Int32.cast(
+            [
+              [0, 1, 2],
+              [3, 4, 5]
+            ]
+          )
+        )
+      end
+
+      it "is indexed as [y, x]" do
+        expect(result.shape).to eq([2, 3])
+        expect(result[0, 1]).to eq(1)
+        expect(result[1, 2]).to eq(5)
+      end
+
+      it "nests #to_a as the written rows" do
+        expect(result.to_a).to eq(
+          [
+            [0, 1, 2],
+            [3, 4, 5]
+          ]
+        )
+      end
+
+      # Numo::NArray[*rows] infers the element type from the Ruby integers
+      # rather than from the band's data type, so a byte band comes back
+      # Int32.
+      it "infers Int32 for a byte band" do
+        expect(result.class).to eq(Numo::Int32)
+      end
+    end
+  end
+
+  describe "#projected_points" do
+    subject(:result) { projected_band.projected_points }
+
+    let(:projected_dataset) do
+      driver.create_dataset("projected_points_test", 3, 2, data_type: data_type).tap do |dataset|
+        geo_transform = GDAL::GeoTransform.new
+        geo_transform.x_origin = 100.5
+        geo_transform.pixel_width = 10.0
+        geo_transform.y_origin = 200.25
+        geo_transform.pixel_height = -10.0
+        dataset.geo_transform = geo_transform
+      end
+    end
+    let(:projected_band) { projected_dataset.raster_band(1) }
+
+    context "byte band" do
+      let(:data_type) { :GDT_Byte }
+
+      # Coordinates are stored in an array typed after the band's pixel data
+      # type, so an integer band truncates the fractional projected
+      # coordinates (100.5 -> 100).
+      it "returns truncated coordinates nested [line][pixel][coord]" do
+        expect(result).to eq(
+          NArray[
+            [
+              [100, 200],
+              [110, 200],
+              [120, 200]
+            ],
+            [
+              [100, 190],
+              [110, 190],
+              [120, 190]
+            ]
+          ]
+        )
+        expect(result.typecode).to eq(NArray::BYTE)
+      end
+
+      it "is indexed as [coord, x, y]" do
+        expect(result.shape).to eq([2, 3, 2])
+        expect(result[0, 1, 0]).to eq(110)
+        expect(result[1, 0, 1]).to eq(190)
+      end
+    end
+
+    context "double band" do
+      let(:data_type) { :GDT_Float64 }
+
+      it "returns exact projected coordinates" do
+        expect(result).to eq(
+          NArray[
+            [
+              [100.5, 200.25],
+              [110.5, 200.25],
+              [120.5, 200.25]
+            ],
+            [
+              [100.5, 190.25],
+              [110.5, 190.25],
+              [120.5, 190.25]
+            ]
+          ]
+        )
+        expect(result.typecode).to eq(NArray::DFLOAT)
+      end
     end
   end
 end

--- a/spec/unit/gdal/grid_spec.rb
+++ b/spec/unit/gdal/grid_spec.rb
@@ -18,6 +18,13 @@ RSpec.describe GDAL::Grid do
         expect { subject.create([], {}, nil) }.to raise_exception GDAL::NoValuesToGrid
       end
     end
+
+    # Points may be passed as a typed NArray instead of a plain Array.
+    context "no points to grid, points given as an NArray" do
+      it "raises a GDAL::NoValuesToGrid" do
+        expect { subject.create(NArray[], {}, nil) }.to raise_exception GDAL::NoValuesToGrid
+      end
+    end
   end
 
   describe "#make_points_pointer" do

--- a/spec/unit/gdal/internal_helpers_spec.rb
+++ b/spec/unit/gdal/internal_helpers_spec.rb
@@ -310,6 +310,44 @@ RSpec.describe GDAL::InternalHelpers do
       end
     end
 
+    # narray has no unsigned integer types and aliases its FLOAT/COMPLEX
+    # constants to the double-precision variants, so several GDAL data types
+    # allocate wider or differently-signed storage than their names suggest.
+    # (NArray's == compares values across types, so each type needs an
+    # explicit typecode assertion.)
+    context "data_type is :GDT_UInt16" do
+      subject { GDAL._narray_from_data_type(:GDT_UInt16, 2) }
+
+      it "allocates signed int storage" do
+        expect(subject.typecode).to eq(NArray::INT)
+      end
+    end
+
+    context "data_type is :GDT_UInt32" do
+      subject { GDAL._narray_from_data_type(:GDT_UInt32, 2) }
+
+      # Values above 2**31 - 1 are not representable in the allocated array.
+      it "allocates signed int storage" do
+        expect(subject.typecode).to eq(NArray::INT)
+      end
+    end
+
+    context "data_type is :GDT_Float32" do
+      subject { GDAL._narray_from_data_type(:GDT_Float32, 2) }
+
+      it "allocates double-precision storage" do
+        expect(subject.typecode).to eq(NArray::DFLOAT)
+      end
+    end
+
+    context "data_type is :GDT_CFloat32" do
+      subject { GDAL._narray_from_data_type(:GDT_CFloat32, 2) }
+
+      it "allocates double-precision complex storage" do
+        expect(subject.typecode).to eq(NArray::DCOMPLEX)
+      end
+    end
+
     context "unknown GDAL data_type" do
       it "raises a GDAL::InvalidDataType exception" do
         expect { GDAL._narray_from_data_type(:bobo) }


### PR DESCRIPTION
## What

Adds the first spec coverage for `GDAL::Dataset::Extensions#to_na` and corrects its doc comment to describe what the method actually returns.

## Why

The narray-to-numo-narray migration (#120) changes this method's observable behavior. Landing pinning specs first makes that migration transparent: its behavior changes will show up as explicit spec diffs instead of silent semantics drift.

The method has never been covered by specs, and its doc example promised per-pixel band-value tuples (`[[0, 10, 99, 2], ...]`) that no implementation in the repo's history ever produced. The real behavior, now pinned:

- the result is indexed `[y, x, band]`, but its nested (`#to_a`) representation is band-major with x/y swapped: `[band][x][y]`;
- the `NMatrix` intermediate widens types: byte bands come back as int (4x memory for RGBA imagery);
- a `:GDT_Float32` conversion comes back double-precision, because narray aliases `NArray::FLOAT` to `DFLOAT`.

## Notes

- No production code changes beyond the doc comment.
- Follow-up context: in #120 this method switches to Numo and gains per-pixel-tuple nesting, preserved dtypes, and a true single-precision Float32 -- the spec diff there will show each of these explicitly.

## Archaeology: where the doc example came from

The per-pixel-tuple doc example (including its reversed alpha order) turns out to be a faithful transcript of code that was deleted in 2014:

- The original implementation was `NArray.to_na(raster_bands.map(&:to_na)).rot90(3)` -- rotate, not transpose. Run against the doc's own RGBA example with 1-D bands, it produces exactly `[[0, 10, 99, 2], [0, 10, 99, 150], [0, 10, 99, 250]]`: per-pixel tuples in reversed pixel order (a 270-degree rotation is transpose + axis flip).
- Commit e2004e2 ("AGDEV-4813 Fixed NArray transposing", Oct 2014) replaced `rot90(3)` with `NArray[*NMatrix.to_na(bands).transpose]` and, in the same commit, changed the doc's alpha from uniform `[250, 250, 250]` to `[250, 150, 2]` to make ordering visible -- transcribing the output of the code being removed. The transpose version produces forward pixel order, so the example was stale in the very commit that wrote it.
- The intent behind both versions was the classic zip-via-transpose idiom: stack bands as rows of a bands-by-pixels matrix and transpose it into pixel tuples. Sound -- for 1-D bands. But `RasterBand#to_na` already returned 2-D `(x, y)` arrays in 2014 (built from `each_by_block` lines), so on real data `NMatrix.to_na` built a 3-D `(x, y, band)` structure and `#transpose` merely swapped its first two dims. The result is the band-major `[band][x][y]` nesting these specs pin -- the documented per-pixel interleave never happened for real 2-D bands.

These specs pin what the method actually does, so the migration in #120 (and any later semantic fix) diffs against reality instead of a 2014 aspiration.

**One redeeming nuance**: the old dimension juggling accidentally landed the band axis last in *index* order, so `result[y, x, true]` really does return one pixel's band values -- the documented "points per pixel" intent holds at the element-access level (pinned by the `result[y, x, true]` spec example). It is only the nested representation -- what `#to_a`, `#inspect`, and iteration show, and what the doc example depicted -- that contradicted the intent for the method's entire life.
